### PR TITLE
Updated usage of link to product_id

### DIFF
--- a/backend/dummy_data/dummy_search_products.py
+++ b/backend/dummy_data/dummy_search_products.py
@@ -11,8 +11,9 @@ dummy_search_products = {
         "link": "https://www.bestbuy.com/site/canon-eos-rebel-t7-dslr-video-camera-with-18-55mm-lens-black/6323758.p?skuId=6323758&ref=212&loc=1",
         "position": 1,
         "price": 479.99,
+        "product_id": "6323758",
         "rating": 4.7,
-        "reviews": 7542,
+        "reviews": 7768,
         "source": "Best Buy",
         "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRvn2Z6xdOLEQkTeKAcrQHbMyBUpBCXc3jAIg5dONHa7WnzNfdyyHSrFG29zuzTut4bl4CqgZLcMgVhh69L1e0jDtzddkeFLKBWfgU8pk80DHByrgpk4puumA&usqp=CAE",
         "title": "Canon Eos Rebel T7 Digital SLR Camera 18-55mm f/3.5-5.6 Is II Kit"
@@ -23,14 +24,15 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-2000D-Rebel-T7-24-1MP-CMOS-1080p-DSLR-Camera-EF-S-18-55mm-f-3-5-5-6-Lens-Intl-Model/213743525?wmlspartner=wlpa&selectedSellerId=101454533",
+        "link": "https://www.walmart.com/ip/Canon-EOS-2000D-Rebel-T7-DSLR-24-1MP-Camera-18-55mm-Lens-Built-in-Wi-Fi-24-1-MP-CMOS-Sensor-DIGIC-4-Image-Processor-Full-HD-Videos-64GB-Memory-Bundle/253206064?wmlspartner=wlpa&selectedSellerId=4680",
         "position": 2,
-        "price": 399.0,
+        "price": 439.0,
+        "product_id": "253206064",
         "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - Digi-Master",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSEUpiIzIaKea1_ofme1-Smi6pHRgtitZkqrnDRyCnG1MzhciPlaZqJcDFWSSzi8abXSbAvbyBjb0Gny4PIx6Uv8J78rr4l4SWB-QuubdZM&usqp=CAE",
-        "title": "Canon Eos 2000D Kit (EF-S 18-55mm Is II)"
+        "reviews": 7768,
+        "source": "Walmart - 33rd Street Camera",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR5wPmvCTQEoZ8_MfjueVFekV09cS5cVhjgEQ1E8xUbe4dJsdcJdMNXKwGNPVNI6hzEqUddXVt0e8_VrPUAi4U2_zvkJq7_eqLmqQmLHcsl&usqp=CAE",
+        "title": "Canon Eos 2000D (Rebel T7) DSLR 24.1MP Camera with 18-55mm Lens with Built-In Wi ..."
       },
       {
         "extensions": [
@@ -38,14 +40,15 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-Bundle-with-Canon-EF-S-18-55mm-f-3-5-5-6-is-II-Lens-2pc-SanDisk-32GB-Memory-Cards-Accessory-Kit/280843241?wmlspartner=wlpa&selectedSellerId=101454533",
+        "link": "https://www.bestbuy.com/site/canon-eos-rebel-sl3-dslr-4k-video-camera-with-ef-s-18-55mm-is-stm-lens/6346259.p?skuId=6346259&utm_source=feed",
         "position": 3,
-        "price": 549.0,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - Digi-Master",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcR1yzd8Id2UAIcyrVpz5yHa16b9mr8ZmZhBXfjwP45Te6HHfd9QvesvTTEf3kzN-WK5mXMVLyswhsX2B3EBcXlbsM__u7YWhsXCpIIDAKc&usqp=CAE",
-        "title": "Canon Eos Rebel T7 DSLR Camera Bundle with Canon EF-S 18-55mm f/3.5-5.6 Is II ..."
+        "price": 749.99,
+        "product_id": "6346259",
+        "rating": 4.6,
+        "reviews": 403,
+        "source": "Best Buy",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSt38ys9w-C--JktGJ0YwIV6j7ODS9SeqQmzf55KTp6iCkV6X8QUnXB2oJXWJla95-0UgCZRMBWZ4zzhCOyQ-A3KF_m43LLdOzhYDSi1wK-ovj-3_Yb__nGLQ&usqp=CAE",
+        "title": "Canon Eos Rebel SL3 DSLR Camera with 18-55mm Lens, Size None, Black"
       },
       {
         "extensions": [
@@ -54,56 +57,13 @@ dummy_search_products = {
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Body-Only/777666746?wmlspartner=wlpa&selectedSellerId=4720",
         "position": 4,
-        "price": 284.39,
-        "rating": 4.5,
-        "reviews": 2030,
+        "price": 283.3,
+        "product_id": "777666746",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - 6AVE Electronics",
         "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTmTlu9UHpsi4n5IBHW4klDHyFYSckMb65a8NscDKe0yvtda5Qu2nrpPbLn9u-2xx8XkbJ-0Jbahf2RYe9-YCen8o2X4zgalQqkANh28XxSbYV5JcL5mFf7&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera (Kit Box)"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-2000D-Rebel-T7-DSLR-24-1MP-Camera-18-55mm-Lens-Built-in-Wi-Fi-24-1-MP-CMOS-Sensor-DIGIC-4-Image-Processor-Full-HD-Videos-64GB-Memory-Bundle/253206064?wmlspartner=wlpa&selectedSellerId=4680",
-        "position": 5,
-        "price": 439.0,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - 33rd Street Camera",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR5wPmvCTQEoZ8_MfjueVFekV09cS5cVhjgEQ1E8xUbe4dJsdcJdMNXKwGNPVNI6hzEqUddXVt0e8_VrPUAi4U2_zvkJq7_eqLmqQmLHcsl&usqp=CAE",
-        "title": "Canon Eos 2000D (Rebel T7) DSLR 24.1MP Camera with 18-55mm Lens with Built-In Wi ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-w-18-55-III/587797593?wmlspartner=wlpa&selectedSellerId=13139",
-        "position": 6,
-        "price": 325.0,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - Paging Zone Inc.",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTXfKNpPzPGqYh7iLJMFn1a4iPoxLLoonDaBsp8Big0eOGuzEUAA6MUQJwBl8JMyUPbt78hkAxDvubGeQtEPLQkDSNj1aMsdXxwdLABkUKsAKZqUJ1rRRpF&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera (w/ 18-55 III)"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-Digital-camera-SLR-24-1-MP-APS-C-4K-24-fps-3x-optical-zoom-EF-S-18-55mm-IS-STM-lens-Wi-Fi-Bluetooth-black/765719423?wmlspartner=wlpa&selectedSellerId=13139",
-        "position": 7,
-        "price": 629.0,
-        "rating": 4.7,
-        "reviews": 583,
-        "source": "Walmart - Paging Zone Inc.",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTfCSPyiskTGYh2IlnhdxZ0kuf2IUQBt6ByiUfgP1fKJKOY7HBF-LHG-SDTE64e5AHev6ForqN-cTV1RW5K_ZVEFAefDx76GIgaRyxaV5HF3NV07hfHhzFl&usqp=CAE",
-        "title": "Canon EOS Rebel SL3 - Digital camera - SLR - 24.1 MP - APS-C - 4K / 24 fps - 3x ..."
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera (Kit BOX)"
       },
       {
         "extensions": [
@@ -114,28 +74,29 @@ dummy_search_products = {
           "LOW PRICE"
         ],
         "link": "https://www.walmart.com/ip/Nikon-D7500-Wi-Fi-4K-Digital-SLR-Camera-with-18-140mm-55-300mm-VR-DX-Lens-500mm-Telephoto-Lens-64GB-Card-Battery-Backpack-Monopod-Kit/651288520?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 8,
+        "position": 5,
         "price": 1685.3,
+        "product_id": "651288520",
         "rating": 4.8,
-        "reviews": 3401,
+        "reviews": 3196,
         "source": "Walmart - BuyDirect & Save",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSFo-RoFnqae9QrZv_6EANHlxzGJbPJ6NzD3zcS0KOBR3yGoV0OHOHx1NNwfiHEnpEcFo-vyFPjSaHud289KXdnawXiW3wdz8wucClTpa9_QYEylml0Q5jjxA&usqp=CAE",
         "title": "Nikon D7500 Wi-Fi 4K Digital SLR Camera with 18-140mm & 55-300mm VR DX Lens + ..."
       },
       {
         "extensions": [
-          "CMOS",
           "With Video",
-          "Black"
+          "Crop Sensor"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-Camera-EF-S-18-55-mm-f-3-5-5-6-III-Lens-Open-Box/772902598?wmlspartner=wlpa&selectedSellerId=101491808",
-        "position": 9,
-        "price": 384.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - SELLOUTDEALS",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcThrFW4JCvx3QK6SNtEUnJKbrQRT-Wu7eZWCs-uFR6AaHNuOUcZd-EwRtQKhG1eLgkqGM4r_gpxawc64NiaEpQe_jJ52j46-e90BQAXlDw&usqp=CAE",
-        "title": "Canon Eos 4000D Kit [18-55 III] DSLR Camera, Wi-Fi Enabled"
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-w-18-55-III/587797593?wmlspartner=wlpa&selectedSellerId=13139",
+        "position": 6,
+        "price": 325.0,
+        "product_id": "587797593",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Paging Zone Inc.",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTXfKNpPzPGqYh7iLJMFn1a4iPoxLLoonDaBsp8Big0eOGuzEUAA6MUQJwBl8JMyUPbt78hkAxDvubGeQtEPLQkDSNj1aMsdXxwdLABkUKsAKZqUJ1rRRpF&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera (w/ 18-55 III)"
       },
       {
         "extensions": [
@@ -143,29 +104,80 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-with-18-55mm-Lens-Built-in-Wi-Fi-New/480175672?wmlspartner=wlpa&selectedSellerId=4680",
-        "position": 10,
-        "price": 425.0,
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-18-Megapixel-Digital-SLR-Camera-with-Lens-0-71-2-17-Black/300559552?wmlspartner=wlpa&selectedSellerId=4831",
+        "position": 7,
+        "price": 349.0,
+        "product_id": "300559552",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Teds Electronics",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcT1Hck5XAdBcuN_IkTSM2GufuZMG-mokCgOIFlcG2wNvC_X31c9mHbK4jvQlY52lJT0Npk8vl1Xc58KZpOV3vZ8e3E0lJhIZiS0WnJX8aObTDwOX2hGS_y98Q&usqp=CAE",
+        "title": "Canon Eos 4000D Kit with 18-55 Is II Lens Digital SLR Cameras - Black"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D3500-24-2MP-DSLR-Camera-AF-P-DX-18-55mm-VR-NIKKOR-Lens-Kit-Accessory-Bundle-64GB-SDXC-Memory-Case-Wide-Angle-2-2x-Telephoto-Flash-Remote-Tripo/888425348?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 8,
+        "price": 899.0,
+        "product_id": "888425348",
         "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - 33rd Street Camera",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRDWxa9SVGtA-i1eIo_V571TTZiPhNcoEO1YHP6nk7H4KSSJcDM3rjcinwVy37sPohPS66G1MRGq4bVfJfwJV7foyzZJo5iQA&usqp=CAE",
-        "title": "Canon Eos Rebel T7 24.1MP Digital SLR Camera with EF-S 18-55 Is II Lens"
+        "reviews": 4066,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR021bd7omsa_tJQZfn-o5omkNE8XUquL6sjjfxnx5_OALcvbpQpiauDGnOKPvT1v4uOU1H5c2ZzZmgj3Pcd9rQqbigi3-N&usqp=CAE",
+        "title": "Nikon D3500 24.2MP DSLR Camera + AF-P DX 18-55mm VR NIKKOR Lens Kit + Accessory ..."
       },
       {
         "extensions": [
-          "With Video",
           "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Kit-18-55-III-DSLR-Camera-Wi-Fi-Enabled-International-Version-Black/474626823?wmlspartner=wlpa&selectedSellerId=3170",
+        "position": 9,
+        "price": 380.77,
+        "product_id": "474626823",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Abes Electronics Center",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSWzApbA6m7C2M0k27HBV5wel2ngidysDQonRP4_oS55664KyDK3jlOazZSB7QOnwfeHKOnFqQf1rzqFBH8SnG1bvt_pL4bAqJaqYTQyXCcJAGh1Ru1n1NItQ&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera with 18-55mm 3.5-5.6 III"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
           "Wi-Fi"
         ],
-        "link": "https://www.bestbuy.com/site/canon-eos-r100-4k-video-mirrorless-camera-with-rf-s-18-45mm-f-4-5-6-3-is-stm-lens-black/6546137.p?skuId=6546137&utm_source=feed",
-        "position": 11,
-        "price": 599.99,
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-EF-S-18-55mm-f-3-5-5-6-II-EF-75-300mm-f-4-5-6-III-Lens-Shoulder-Bag-32GB-Memory-Card-64GB-2x-Tripod-Slave-Flash-Top-Va/854644344?wmlspartner=wlpa&selectedSellerId=9024",
+        "position": 10,
+        "price": 789.0,
+        "product_id": "854644344",
         "rating": 4.7,
-        "reviews": 475,
-        "source": "Best Buy",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRNLqE8gMhjyaJdbFEZ-v4j-ydPsvvXo4g411pDXLm3njIdi0YVhexL5KJ73FIuI7O-BBloHnQNoKi2NeaE2Z7feXYZmOulXZUJJlKHwifyKMIyJLsWVVYFHyk&usqp=CAE",
-        "title": "Canon Eos R100 Mirrorless Camera with RF-S 18-45mm Lens"
+        "reviews": 7768,
+        "source": "Walmart - Photo & Beyond",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRTBfK6CREPWgB74OCTCU1WnNXLBUHYiCLvXB6HD7Goo-fCk0AGXuV-dk5SjHTk8_hXMzw7thmynmoke4cWFu55voPcwhaHcS8Ce8x_a7s&usqp=CAE",
+        "title": "Canon Eos Rebel T7 DSLR Camera + EF-S 18-55mm f/3.5-5.6 Is II + EF 75-300mm f/4-5 ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black",
+          "SALE"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-LensDX-format-24-2MP-CMOS-Sensor-and-EXPEED-4-Image-processor-32GB-card-other-photo-accesories/571240177?wmlspartner=wlpa&selectedSellerId=8054",
+        "position": 11,
+        "price": 899.0,
+        "product_id": "571240177",
+        "rating": 4.7,
+        "reviews": 4066,
+        "source": "Walmart - Deal-Expo",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQ43U9HQ5pokE8m5HNgtJi-dofKqAIrEDqgX7_jSt-rCjbDXf_zZLUZUKzDLZ70eGCL_yLWPrzDl-Rv3LZhYfaTnq_xTvHF_w&usqp=CAE",
+        "title": "Nikon D3500 DSLR Camera with 18-55mm LensDX-format 24.2MP CMOS Sensor and EXPEED ..."
       },
       {
         "extensions": [
@@ -177,8 +189,9 @@ dummy_search_products = {
         "link": "https://www.bestbuy.com/site/sony-alpha-a7-iii-mirrorless-video-camera-with-fe-28-70-mm-f3-5-5-6-oss-lens-black/6213100.p?skuId=6213100&utm_source=feed",
         "position": 12,
         "price": 1999.99,
+        "product_id": "6213100",
         "rating": 4.8,
-        "reviews": 1594,
+        "reviews": 2063,
         "source": "Best Buy",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSzYip4t9alVIY6lkCcQ7P-q1ubE_dJdrD4cmHeTCq0wA9Gi1rv-Ayl4VjnTtsaHsTneSBIV4OMz5BH5HhSGXtaKXuOdrbk--84WVsr9y4jyqLthlb4IOsD&usqp=CAE",
         "title": "Sony Alpha A7 III Mirrorless Digital Camera with 28-70mm Lens"
@@ -187,31 +200,33 @@ dummy_search_products = {
         "extensions": [
           "CMOS",
           "With Video",
-          "Wi-Fi"
+          "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D5600-Digital-SLR-Camera-18-55mm-VR-Nikon-70-300mm-EXT-BATT-64GB/615002354?wmlspartner=wlpa&selectedSellerId=6811",
+        "link": "https://www.walmart.com/ip/Nikon-D7500-DX-format-Digital-SLR-Camera-with-Nikon-18-55-Lens-Wi-Fi-New-Int-Model/165097806?wmlspartner=wlpa&selectedSellerId=6558",
         "position": 13,
-        "price": 1398.0,
-        "rating": 4.7,
-        "reviews": 4384,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSaYbt2vASO9wnbdpiLEbhsKPXDU7C8b220sRKcpbuj0lC34xqlpzlQWksR63-RIc20cfl3XamHpiWfHWeYDI4FoEd5ear5TbqiZwq5MMJo&usqp=CAE",
-        "title": "Nikon D5600 Digital SLR Camera + 18-55mm VR + Nikon 70-300mm + EXT Batt + 64GB"
+        "price": 1054.94,
+        "product_id": "165097806",
+        "rating": 4.8,
+        "reviews": 3196,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQncTB__Jw8SsbBosBp-7WIT0NaXoaSGruqzvLXD3ZuVcsPK-D3LhCWLlYit6_La_qGjZ8XOn2wQ2A8YyxEjgl_mgjjWMmVn2Ark8lYwSHjVvxIXXBPL0IC&usqp=CAE",
+        "title": "Nikon D7500 DX-Format Digital SLR Camera with Nikon 18-55 Lens (International Model)"
       },
       {
         "extensions": [
           "CMOS",
           "With Video",
-          "Wi-Fi"
+          "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-EF-S-18-55mm-f-3-5-5-6-II-EF-75-300mm-f-4-5-6-III-Lens-Shoulder-Bag-32GB-Memory-Card-64GB-2x-Tripod-Slave-Flash-Top-Va/854644344?wmlspartner=wlpa&selectedSellerId=9024",
+        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-18-140mm-VR-70-300mm-Lens-Bundle-420-800mm-Preset-f-8-Telephoto-128GB-Card-Tripod-Flash-More-23pc/936610461?wmlspartner=wlpa&selectedSellerId=5323",
         "position": 14,
-        "price": 789.0,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - Photo & Beyond",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRTBfK6CREPWgB74OCTCU1WnNXLBUHYiCLvXB6HD7Goo-fCk0AGXuV-dk5SjHTk8_hXMzw7thmynmoke4cWFu55voPcwhaHcS8Ce8x_a7s&usqp=CAE",
-        "title": "Canon Eos Rebel T7 DSLR Camera + EF-S 18-55mm f/3.5-5.6 Is II + EF 75-300mm f/4-5 ..."
+        "price": 1699.0,
+        "product_id": "936610461",
+        "rating": 4.8,
+        "reviews": 3196,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQ-zjqNZlvK0E8hh0Jy6k2ga5elG-yaqleV5G29mBG3yQDkgQpIBpZZGCMG5k_WjBAqOlEgKdCyu1VrDI9dHUc5D9WgcC3w5FwxyyaRPNw&usqp=CAE",
+        "title": "Nikon D7500 DSLR Camera with 18-140mm VR and 70-300mm Lens Bundle with 420-800mm ..."
       },
       {
         "extensions": [
@@ -219,29 +234,15 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-DSLR-Camera-with-18-55mm-Lens-Black/648165854?wmlspartner=wlpa&selectedSellerId=13139",
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-Bundle-with-Canon-EF-S-18-55mm-f-3-5-5-6-is-II-Lens-2pc-SanDisk-32GB-Memory-Cards-Accessory-Kit/280843241?wmlspartner=wlpa&selectedSellerId=5323",
         "position": 15,
-        "price": 585.0,
+        "price": 549.0,
+        "product_id": "280843241",
         "rating": 4.7,
-        "reviews": 583,
-        "source": "Walmart - Paging Zone Inc.",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRhlr2vkyFsd04SeleyYqvo1V5U6PiKXfcYvPl4a54zAOQNmFvjpVDPXPDGUqUbmB18vmdF3GazhKfbQweFT8-8HKEIVcqZBA&usqp=CAE",
-        "title": "Canon Eos Rebel SL3 DSLR Camera with 18-55mm Lens (Black)"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-Black-1590/388465242?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 16,
-        "price": 799.95,
-        "rating": 4.7,
-        "reviews": 4107,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQN_8QeKLnJCZruCb3fITztUMFtlJ6cTosEL4gHgUQobWshL3sqYXBEUAL3dptinp1gDZZyqV4jXX32mufK4B6Ia8RrPYBs8XXIz8nCZBnZy6iwQbr63ZofFg&usqp=CAE",
-        "title": "Nikon D3500 DSLR Camera,, with 18-55mm Lens"
+        "reviews": 7768,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcR1yzd8Id2UAIcyrVpz5yHa16b9mr8ZmZhBXfjwP45Te6HHfd9QvesvTTEf3kzN-WK5mXMVLyswhsX2B3EBcXlbsM__u7YWhsXCpIIDAKc&usqp=CAE",
+        "title": "Canon Eos Rebel T7 DSLR Camera Bundle with Canon EF-S 18-55mm f/3.5-5.6 Is II ..."
       },
       {
         "extensions": [
@@ -250,14 +251,64 @@ dummy_search_products = {
           "Black",
           "SALE"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-lens-Buzz-Photo-accessories-With-32GB-memory-Card/159702419?wmlspartner=wlpa&selectedSellerId=18065",
-        "position": 17,
-        "price": 899.0,
+        "link": "https://www.walmart.com/ip/Canon-EOS-90D-DSLR-Camera-18-55mm-IS-STM-3-Lens-Kit-32GB-Best-Value-Kit/374320115?wmlspartner=wlpa&selectedSellerId=7869",
+        "position": 16,
+        "price": 1219.95,
+        "product_id": "374320115",
         "rating": 4.7,
-        "reviews": 4107,
-        "source": "Walmart - BuzzPhoto",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQtW639b_t0b3H1ZxviaRZh4B4y4yGD-rSucT0mMO5WIgcJgEb2hiWCD7mikYAgkUwEC8tCqf_FZ7qTZeCzWvEWRyBYLxZ1&usqp=CAE",
-        "title": "Nikon D3500 DSLR Camera with 18-55mm lens+Buzz-Photo Accessories with 32GB Memory ..."
+        "reviews": 2297,
+        "source": "Walmart - Redtagcamera",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQuRGU0m4qFuDXLGd0x7tdbBma1TMrupdtOp8AVAWoYrrDG6d2f7istUfHoY0GnxZ_898cmaX5JzgFqpmX4lfQyT8jhRbtvFW46dXUWeDjHRsNzhDGh72hdbw&usqp=CAE",
+        "title": "Canon Eos 90D DSLR Camera + 18-55mm Is STM 3 Lens Kit + 32GB Best Value Kit"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-90D-DSLR-Camera-w-Canon-18-55mm-STM-Lens-Kit-Pro-Photo-Video-Accessories-Including-128GB-Memory-LED-Light-Condenser-Micorphone-60-Tripod-Mo/424650185?wmlspartner=wlpa&selectedSellerId=4680",
+        "position": 17,
+        "price": 1329.0,
+        "product_id": "424650185",
+        "rating": 4.7,
+        "reviews": 2297,
+        "source": "Walmart - 33rd Street Camera",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQ5i5qqTcPFNiQZ1yUD7KHzwjyDnC0oUkgCVBfkKJOOYET9rMHySB-16flqhLruAySHnOYgoPYpohaC4gE0FpLsbW4fLuvCkmqvaKnfSNhc&usqp=CAE",
+        "title": "Canon Eos 90D DSLR Camera w/Canon 18-55mm STM Lens Kit + Pro Photo & Video ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black",
+          "$50.73 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-with-18-140mm-Lens/100292465?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 18,
+        "price": 963.97,
+        "product_id": "100292465",
+        "rating": 4.8,
+        "reviews": 3196,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSelIs95_0iI9QKUlOny8cQedmhUjjUCUbcumafChsfE_6bM3okY--3hyZhYJn3cFgQVPsCF9cWA3yfIPG1NRSIvJIg20PF7VLBplSGhXxaTN2YeIDDuxuB5Q&usqp=CAE",
+        "title": "Nikon D7500 DSLR Camera with 18-140mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-w-EF-S-18-55mm-f-3-5-5-6-II-EF-75-300mm-f-4-5-6-III-Lens-Wide-Angle-Telephoto-Lenses-Portable-Tripod-Memory-Card-Delux/648943818?wmlspartner=wlpa&selectedSellerId=13139",
+        "position": 19,
+        "price": 699.0,
+        "product_id": "648943818",
+        "rating": 4.7,
+        "reviews": 7768,
+        "source": "Walmart - Paging Zone Inc.",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQTj2yws_87CotPCNU4KCqnTY2Fs4y_vTV1cRmz_94sOau2W9exmMWZffn--LkYFtLH1Oqj7j2p25OKkludapmfHp_yisOv91Dgv29KIZT6&usqp=CAE",
+        "title": "Canon Eos Rebel T7 DSLR Camera w/EF-S 18-55mm f/3.5-5.6 Is II & EF 75-300mm f/4-5 ..."
       },
       {
         "extensions": [
@@ -265,57 +316,47 @@ dummy_search_products = {
           "CMOS",
           "Wi-Fi"
         ],
-        "link": "https://www.bestbuy.com/site/canon-eos-r6-mark-ii-mirrorless-camera-with-rf-24-105mm-f-4l-is-usm-lens-black/6525215.p?skuId=6525215&utm_source=feed",
-        "position": 18,
-        "price": 3599.99,
-        "rating": 4.7,
-        "reviews": 230,
-        "source": "Best Buy",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQCacdeEHUsn-EeGV29iAzh0hJ_SvwhIxFPwF3QVsu0WEI0jZd8_SvNAvSYA3zMRAkhWkYCfNw3WQiM-w08cwjorVssBVyg8ju8S6vziXPAaRqQmKFBCTTzUA&usqp=CAE",
-        "title": "Canon Eos R6 Mark II Mirrorless Camera with RF 24-105mm F4L Is USM Lens"
-      },
-      {
-        "extensions": [
-          "Detachable Flash"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-Bundle-EF-S-18-55mm-f-3-5-5-6-II-Lens-55-250mm-f-4-5-6-STM-2pc-SanDisk-32GB-Memory-Cards-Accessory-Kit/592020897?wmlspartner=wlpa&selectedSellerId=4680",
-        "position": 19,
-        "price": 789.0,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - 33rd Street Camera",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRr1lspItd7hEGesjXFNcTWb1P89lJOOSOTolMggxR9F2SB3H_asRxx3B44W5yIPVBmFi2xryAlhuvdBbCh22hdwdYdqgPRzw&usqp=CAE",
-        "title": "Canon Eos Rebel T7 DSLR Camera Bundle with Canon EF-S 18-55mm f/3.5-5.6 Is II ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "SALE"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-FREE-Buzz-Photo-Microfiber-Cleaning-Cloth/460191637?wmlspartner=wlpa&selectedSellerId=18065",
+        "link": "https://www.bestbuy.com/site/canon-eos-r50-4k-video-mirrorless-camera-with-rf-s-18-45mm-f-4-5-6-3-is-stm-lens-white/6535120.p?skuId=6535120&utm_source=feed",
         "position": 20,
-        "price": 899.0,
+        "price": 799.99,
+        "product_id": "6535120",
         "rating": 4.7,
-        "reviews": 4107,
-        "source": "Walmart - BuzzPhoto",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSm4wydLcLEmuBw-tvEX4h1rkP64LrRIZb-2oBlRIBhjF2rnUGDKUXkVK89FRIArb70S1Ifn2bXQC4dxV4JQlNmdiyZcIqi1A&usqp=CAE",
-        "title": "Nikon D3500 DSLR Camera with 18-55mm Lens + Free Buzz-Photo Microfiber Cleaning Cloth"
+        "reviews": 526,
+        "source": "Best Buy",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSQrEbBDLHUxkBvicOqnF1Q_x5otoK5GWtUETR_MFTjqiaC2ka3mm3272wyI3TrNA5KfOa7Go4uyW0aPj0zn0ddziEDzYEJTyDwRBCXAurD5vFq_JUrl2mguA&usqp=CAE",
+        "title": "Canon Eos R50 Mirrorless Camera with 18-45mm Lens (White)"
       },
       {
         "extensions": [
           "CMOS",
           "With Video",
-          "Silver"
+          "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-with-18-55mm-VR-Lens-70-300-Lens-64GB-Bundle-Kit/396436556?wmlspartner=wlpa&selectedSellerId=6811",
+        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-Black-1590/388465242?wmlspartner=wlpa&selectedSellerId=4720",
         "position": 21,
-        "price": 1552.0,
+        "price": 799.95,
+        "product_id": "388465242",
         "rating": 4.7,
-        "reviews": 4384,
+        "reviews": 4066,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQN_8QeKLnJCZruCb3fITztUMFtlJ6cTosEL4gHgUQobWshL3sqYXBEUAL3dptinp1gDZZyqV4jXX32mufK4B6Ia8RrPYBs8XXIz8nCZBnZy6iwQbr63ZofFg&usqp=CAE",
+        "title": "Nikon D3500 DSLR Camera,, with 18-55mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D5600-Digital-SLR-Camera-18-55mm-VR-Nikon-70-300mm-EXT-BATT-64GB/615002354?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 22,
+        "price": 1398.0,
+        "product_id": "615002354",
+        "rating": 4.7,
+        "reviews": 4414,
         "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTIJ3KMi0wPd3E-X5-xaJcdX_MPFsvu0odFykd0Rl02gVhSQxq0lOvRbgudmW4Fm6sLBnAH8y3mdJwacra78IoQ8qxXqWubyd-jWWqV1cQb&usqp=CAE",
-        "title": "Nikon D5600 DSLR Camera with 18-55mm VR Lens + 70-300 Lens + 64GB Bundle Kit"
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSaYbt2vASO9wnbdpiLEbhsKPXDU7C8b220sRKcpbuj0lC34xqlpzlQWksR63-RIc20cfl3XamHpiWfHWeYDI4FoEd5ear5TbqiZwq5MMJo&usqp=CAE",
+        "title": "Nikon D5600 Digital SLR Camera + 18-55mm VR + Nikon 70-300mm + EXT Batt + 64GB"
       },
       {
         "extensions": [
@@ -324,10 +365,11 @@ dummy_search_products = {
           "Black"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-with-18-55mm-Lens-Kit-with-Steady-Grip-Tripod-32GB-Memory-Accessory-Kit/458878673?wmlspartner=wlpa&selectedSellerId=932",
-        "position": 22,
+        "position": 23,
         "price": 499.0,
+        "product_id": "458878673",
         "rating": 4.7,
-        "reviews": 7542,
+        "reviews": 7768,
         "source": "Walmart - OneStopShop",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSrEtMUYLXpJhZyBAz2XKSq5ueBLG0Wdya1ln0UmeCojtTs6_QBQOiheJBmWeGOc7PjZyJp5fVAISaRFUEXVDWlMrHBDDTxSQ&usqp=CAE",
         "title": "Canon Eos Rebel T7 DSLR Camera with 18-55mm Lens Kit with Steady Grip Tripod 32GB ..."
@@ -339,103 +381,81 @@ dummy_search_products = {
           "Black",
           "SALE"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-LensDX-format-24-2MP-CMOS-Sensor-and-EXPEED-4-Image-processor-32GB-card-other-photo-accesories/571240177?wmlspartner=wlpa&selectedSellerId=8054",
-        "position": 23,
+        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-lens-Buzz-Photo-accessories-With-32GB-memory-Card/159702419?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 24,
         "price": 899.0,
+        "product_id": "159702419",
         "rating": 4.7,
-        "reviews": 4107,
-        "source": "Walmart - Deal-Expo",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQ43U9HQ5pokE8m5HNgtJi-dofKqAIrEDqgX7_jSt-rCjbDXf_zZLUZUKzDLZ70eGCL_yLWPrzDl-Rv3LZhYfaTnq_xTvHF_w&usqp=CAE",
-        "title": "Nikon D3500 DSLR Camera with 18-55mm LensDX-format 24.2MP CMOS Sensor and EXPEED ..."
+        "reviews": 4066,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQtW639b_t0b3H1ZxviaRZh4B4y4yGD-rSucT0mMO5WIgcJgEb2hiWCD7mikYAgkUwEC8tCqf_FZ7qTZeCzWvEWRyBYLxZ1&usqp=CAE",
+        "title": "Nikon D3500 DSLR Camera with 18-55mm lens+Buzz-Photo Accessories with 32GB Memory ..."
       },
       {
         "extensions": [
           "CMOS",
           "With Video",
-          "Black",
+          "Wi-Fi",
+          "$9.26 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-5-Lens-Kit-Nikon-18-55mm-70-300mm-500mm-and-More/341713212?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 25,
+        "price": 1771.75,
+        "product_id": "341713212",
+        "rating": 4.8,
+        "reviews": 3196,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRY-YuW8-x8OEt-CpZy7-_1RMI4F3ZdUOtO04ZEFFtt8UKkcYftWYIysYekdBJ3gvXob_yb16O7s4wtWv1Uwouq6eZ3pKgMLqqjkCmj7q0Zx8rQjynPCNX1&usqp=CAE",
+        "title": "Nikon D7500 DSLR Camera | 5 Lens Kit Nikon 18-55mm | 70-300mm | 500mm and More"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
           "SALE"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-Digital-SLR-Camera-with-18-55mm-Lens-Kit-18-Megapixel-Sensor-Wi-Fi-DIGIC4-SanDisk-32GB-Memory-Card-and-Live-View-Shooting/771229626?wmlspartner=wlpa&selectedSellerId=101468958",
-        "position": 24,
-        "price": 336.49,
-        "rating": 4.5,
-        "reviews": 465,
-        "source": "Walmart - sals electronics",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTS76vegDCmBYtp7ozV2sPnAXGN2EA97884jspO2hm8tG6_657YSFotCDs1BG2ojEkrC4tUuVrCkJANoO9czVrAWQaNzBEw7VNHsux05xfDZgqq6ErgbHtmMQ&usqp=CAE",
-        "title": "Canon Eos Rebel T100 DSLR Camera with 18-55mm Lens"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-Eos-Canon-T7-Digital-SLR-Camera-with-18-55mm-Prime-Lens-Bundle/341489152?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 25,
-        "price": 494.7,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSGFuEXiCtzYTfoSiFoAdy09xNBmiVQPWFxkE7hJzYOMJhnxU1NKUq9rvEEnjG3KnaEU4AasePu93IdC4pccQfEQSUydc3F&usqp=CAE",
-        "title": "Canon Eos 2000D (Rebel T7) Digital SLR Camera with 18-55mm Prime Lens Bundle"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18MP-with-EF-S-18-55mm-Zoom-Lens-SanDisk-32GB-Memory-Card-Tripod-ZeeTech-Accessory-Bundle/456332687?wmlspartner=wlpa&selectedSellerId=6558",
+        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-FREE-Buzz-Photo-Microfiber-Cleaning-Cloth/460191637?wmlspartner=wlpa&selectedSellerId=18065",
         "position": 26,
-        "price": 379.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTbECzel4QrITeDnWgyA8E2dU1VTwvLE6814WjUGp-0y1BxHLS8qwbjdsdgM5wtU87iKlN9Q-7v68FFnizkuH9N2V6FHQa7RcmKOHj_UGTBtFjPrGGkTVBY&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera 18MP with EF-S 18-55mm Zoom Lens + ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-64GB-Bundle/268742803?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 27,
-        "price": 1298.0,
+        "price": 899.0,
+        "product_id": "460191637",
         "rating": 4.7,
-        "reviews": 4107,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRT1UXJbAOCMsEmwZKBTy0ryFb-qo1LVrUdiWsPnhFD1zC79Kr7HSPAhZQY22tdiCeAmmB_UKKyRHNJdXTDmFVp10R-2sJ6SDvhfHgqrPw&usqp=CAE",
-        "title": "Nikon D3500 DSLR Camera with 18-55mm Lens & 64GB Bundle, Black"
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7-DSLR-Camera-with-18-55mm-f-3-5-5-6-is-Zoom-Lens-75-300mm-F-4-5-6-III-Lens-32GB-Card-Tripod-Case-and-More-24pc-Bundle/923696410?wmlspartner=wlpa&selectedSellerId=5323",
-        "position": 28,
-        "price": 789.0,
-        "rating": 4.7,
-        "reviews": 7542,
-        "source": "Walmart - Als Variety",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRyjehlx3AybU8UYZ0WoLmlpFqnAHzqiTYpQZnAewDk29d51uyAaYs24sk5Dzgo8oq4Raf37MvxYzkVYrCgbB5ZzPhjnI8kX0jXXnVCbiw&usqp=CAE",
-        "title": "Canon Eos Rebel T7 DSLR Camera with 18-55mm f/3.5-5.6 Is Zoom Lens + 75-300mm f/4 ..."
+        "reviews": 4066,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSm4wydLcLEmuBw-tvEX4h1rkP64LrRIZb-2oBlRIBhjF2rnUGDKUXkVK89FRIArb70S1Ifn2bXQC4dxV4JQlNmdiyZcIqi1A&usqp=CAE",
+        "title": "Nikon D3500 DSLR Camera with 18-55mm Lens + Free Buzz-Photo Microfiber Cleaning Cloth"
       },
       {
         "extensions": [
           "CMOS",
-          "Crop Sensor",
+          "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-250D-Rebel-SL3-DSLR-Camera-18-55mm-Lens-Black-Creative-Filter-Set-Bag-Sandisk-Ultra-64GB-Card-Electronics-Cleaning-And-More-International-M/786971131?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 29,
-        "price": 629.95,
+        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-with-18-55mm-Lens-Buzz-Photo-Advanced-kit/839331503?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 27,
+        "price": 999.0,
+        "product_id": "839331503",
         "rating": 4.7,
-        "reviews": 583,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRMSFKNyhnI6ejo1hjRExohGFJO-JnIuDEuLnQIlf4zeemyVB9aTHhel4UfLw8Eajz1hVQRcmqWLajj8hWX3Smjq4OPcYQkUiv-3kqZWPw00KXyCteoMyWo&usqp=CAE",
-        "title": "Canon Eos 250D / Rebel SL3 DSLR Camera with 18-55mm Lens Black + Creative Filter ..."
+        "reviews": 4414,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRHRd6SuqLGLBzDmwhi8PGc10kutj4QDGt54o-lWsdxDsxGBkaNtFAO9NuNT-SFG7gWyvWY0-me20ggp6nlBdMhdI8O0A_i&usqp=CAE",
+        "title": "Nikon D5600 DSLR Camera with 18-55mm Lens + Buzz-Photo Advanced Kit, Black"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-Zoom-Lens-32GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/920838115?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 28,
+        "price": 399.99,
+        "product_id": "920838115",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSIzxyR0jEdX_u8xZNfKeEYOTBYltp8IK7fZ6tb08x7hHVdp-FGTsu8ecxd_rci39PILtM8fSBsal5-ce_QFOyrS463r_9FiOOYVRxmW8Hn6DZyCE2cseGeRX9C&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm Zoom Lens + 32GB ..."
       },
       {
         "extensions": [
@@ -444,10 +464,11 @@ dummy_search_products = {
           "Wi-Fi"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-250D-Rebel-SL3-DSLR-Camera-with-18-55mm-f-3-5-5-6-Zoom-Lens-32GB-Card-Tripod-Case-and-More-18pc-Bundle-DSLR/943333087?wmlspartner=wlpa&selectedSellerId=5323",
-        "position": 30,
-        "price": 698.0,
-        "rating": 4.7,
-        "reviews": 583,
+        "position": 29,
+        "price": 699.0,
+        "product_id": "943333087",
+        "rating": 4.6,
+        "reviews": 403,
         "source": "Walmart - Als Variety",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQtLykvbz9yD2L4athUBiw8nfscueN37qFFPCNuSxbRUWeXkYWhloe9AO7ARGZW-joHd9aPSi7JCjgUBtXBPxrRWuo8Hwj6391G312KeYiV&usqp=CAE",
         "title": "Canon Eos 250D (Rebel Sl3) DSLR Camera with 18-55mm f/3.5-5.6 Zoom Lens + 32GB ..."
@@ -458,147 +479,14 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-with-18-55mm-Lens-Buzz-Photo-Advanced-kit/839331503?wmlspartner=wlpa&selectedSellerId=18065",
-        "position": 31,
-        "price": 999.0,
-        "rating": 4.7,
-        "reviews": 4384,
-        "source": "Walmart - BuzzPhoto",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRHRd6SuqLGLBzDmwhi8PGc10kutj4QDGt54o-lWsdxDsxGBkaNtFAO9NuNT-SFG7gWyvWY0-me20ggp6nlBdMhdI8O0A_i&usqp=CAE",
-        "title": "Nikon D5600 DSLR Camera with 18-55mm Lens + Buzz-Photo Advanced Kit, Black"
-      },
-      {
-        "extensions": [
-          "With Video",
-          "CMOS",
-          "Wi-Fi"
-        ],
-        "link": "https://www.bestbuy.com/site/canon-eos-r50-4k-video-mirrorless-camera-with-rf-s-18-45mm-f-4-5-6-3-is-stm-lens-white/6535120.p?skuId=6535120&utm_source=feed",
-        "position": 32,
-        "price": 799.99,
-        "rating": 4.7,
-        "reviews": 500,
-        "source": "Best Buy",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSsq9hfYYEI58GZ9EQcr-XfpRQc5M2kkKiCE_0xgPFrw2O90yUJImoz-3fzWDNcZfOB97XcCmwNAhkCiRM_fv5tjj-50WMbwZDBBXXQvWNfgFt63qRGWmrbsQ&usqp=CAE",
-        "title": "Canon Eos R50 Mirrorless Camera with 18-45mm Lens (White)"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-250D-DSLR-Camera-with-EF-S-18-55mm-f-4-5-6-IS-STM-Lens-Black/387804811?wmlspartner=wlpa&selectedSellerId=5568",
-        "position": 33,
-        "price": 649.95,
-        "rating": 4.7,
-        "reviews": 1129,
-        "source": "Walmart - SSE Photo & Video",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQAAdtxVtLic-Gr-VfUEHZRvKTkBxnt0qSygNUo5ooK0fRkQAm_CgH3SrXvnHJHzl_HE8mAdW7qnM6VDQs5ScKt-UFOBlayjQpQOCZyqyUefwcJgNR1oe8C&usqp=CAE",
-        "title": "Canon Eos 250D Kit EF-S 18-55mm STM (Black)"
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-18-Megapixel-Digital-SLR-Camera-with-Lens-0-71-2-17-Black/820481078?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 34,
-        "price": 470.01,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQUA7eoobBp-zGvw5b3H0jVeaSpRfQ3N6Y6YWP26yNDl4cGpLgVOz2PnCs5VxmZzX_3vn2vFRq1nGzaA1BckW46-rG8svvNLWEEuGSPwC6WLKOrLj2DKKwDiQ&usqp=CAE",
-        "title": "Canon Eos Rebel 4000D Digital SLR Camera with EF-S 18-55mm f/3.5-5.6 DC III Lens ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D7200-D7500-DSLR-Camera-with-18-140mm-Prime-Lens-Nikon-50mm-1-8G-Lenses-Bundle/422515527?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 35,
-        "price": 1490.0,
-        "rating": 4.8,
-        "reviews": 2341,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSv_ZC1FHSwjKeKFabABiJQA5kDlLtRARst1pl6_pxwB61G3U2AdRZsmaSOQAyts-GhPLpgNwrmx_IvMzGqd3bao2JdDVPNyTrJj12fFV8sp-QChaZxxepYTg&usqp=CAE",
-        "title": "Nikon D7200 DSLR Camera with 18-140mm Prime Lens Kit"
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-Lens-SanDisk-128GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/535268164?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 36,
-        "price": 439.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRvRsP0TYAKGmgPUdUAdmsvL8uZTwxPbYJeBTaBLicAPcRGXTlk3UtMgr4C39HtqbcksREE4t_saPN2RUp2cTnslbU_45vApfxigj7GVD-n2hvNiMnhUKoIng&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm Lens, SanDisk 128GB Memory ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-EF-S-18-55mm-Zoom-Lens-SanDisk-32GB-Memory-Card-ZeeTech-Accessory-Bundle/568398901?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 37,
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18MP-with-EF-S-18-55mm-Zoom-Lens-SanDisk-32GB-Memory-Card-Tripod-ZeeTech-Accessory-Bundle/456332687?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 30,
         "price": 379.99,
-        "rating": 4.5,
-        "reviews": 2030,
+        "product_id": "456332687",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQkF-iMhJzit0uLT_TH3G28T4F6N5j1PTOzEqbO7mXazRamgQSg3D1ucXuLlbHDqjQSbwHdovIdgffZRI32l0HBoSTF8h8gp3vsyCQyb2zVdlWuF7S0m1pQXQ&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with EF-S 18-55mm Zoom Lens + SanDisk ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-250D-Rebel-SL3-24-1MP-4K-Digital-SLR-Camera-with-18-55-mm-Lens-ALL-YOU-NEED-KIT/129646467?wmlspartner=wlpa&selectedSellerId=8054",
-        "position": 38,
-        "price": 579.0,
-        "rating": 4.7,
-        "reviews": 583,
-        "source": "Walmart - Deal-Expo",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSZ68Rf0sC7S0ueZV_6ifHlmLDHrLRCMkju61a5AMBvHfaSNxL0oNt30m-x3_LzZTMIiWTXMkeGusXAo8fSAFrGepOLXVt7Fw&usqp=CAE",
-        "title": "Canon Eos 250D / Rebel SL3 24.1MP 4K Digital SLR Camera + All You Need Kit"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-Zoom-Lens-32GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/920838115?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 39,
-        "price": 399.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSIzxyR0jEdX_u8xZNfKeEYOTBYltp8IK7fZ6tb08x7hHVdp-FGTsu8ecxd_rci39PILtM8fSBsal5-ce_QFOyrS463r_9FiOOYVRxmW8Hn6DZyCE2cseGeRX9C&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm Zoom Lens + 32GB ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18MP-with-EF-S-18-55mm-Zoom-Lens-SanDisk-64GB-Memory-Card-Tripod-ZeeTech-Accessory-Bundle/613308159?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 40,
-        "price": 379.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcToA2Zs4TIJV316pbHjaVEtQEVwJQ_gVeIQmQf5rEf97r5eL-91VtFlW1aUXDZGIVVhCsnRKGdblRnvRiFTY9Y_mfkXnDssbzfVC_gW0NmD&usqp=CAE",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTbECzel4QrITeDnWgyA8E2dU1VTwvLE6814WjUGp-0y1BxHLS8qwbjdsdgM5wtU87iKlN9Q-7v68FFnizkuH9N2V6FHQa7RcmKOHj_UGTBtFjPrGGkTVBY&usqp=CAE",
         "title": "Canon Eos 4000D / Rebel T100 DSLR Camera 18MP with EF-S 18-55mm Zoom Lens + ..."
       },
       {
@@ -608,58 +496,14 @@ dummy_search_products = {
           "Silver"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-4000D-T100-Digital-Camera-with-EF-S-18-55MM-F-3-5-5-6-III-Lens-Essential-Accessories-Bundle/239645911?wmlspartner=wlpa&selectedSellerId=18065",
-        "position": 41,
+        "position": 31,
         "price": 379.0,
-        "rating": 4.5,
-        "reviews": 2030,
+        "product_id": "239645911",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - BuzzPhoto",
         "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQsbHQg0DMDr8nY1pTRWisNJyjpZHKTk4SshQ9ElHLizuRrP8jhWVlRFHwdaREFaFg4FCH7TiaEbAP6nQ3qlkCrF4MiHCScQQQWbkIZksztHovCqp069RW6&usqp=CAE",
         "title": "Canon Eos 4000D / T100 Digital Camera with EF-S 18-55mm f/3.5-5.6 III Lens + ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black",
-          "SALE"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D500-20-9-Megapixel-Digital-SLR-Camera-with-Lens-7-87-19-69-Black/111532611?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 42,
-        "price": 3878.06,
-        "rating": 4.8,
-        "reviews": 2708,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR4AA91qnG1HLfK0jSFlmruCLZNOH6LZ6oS_LO-D3uH2NAbMx1cObj4sd-q_FKYTz5AItEQ3uizveSE6gxDiWAzDWTTKaIKgzZGlg2rqFmBXc0XBEEslGGP&usqp=CAE",
-        "title": "Nikon D500 DSLR Camera Sports and Wildlife Kit"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-AF-P-18-55mm-VR-6PC-Graduated-Filter-96GB-Bundle/601274947?wmlspartner=wlpa&selectedSellerId=441",
-        "position": 43,
-        "price": 1089.99,
-        "rating": 4.7,
-        "reviews": 4384,
-        "source": "Walmart - Tri State Camera",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQANnl-QRIyIPmu13BNjpgf2i3pfqrhpyLOESaJCRl9-EUdnyJ0F28QeZHxiyIAhdyr0LuBIyYvHx62ixQNbMArGPekMm6Ez03DuMgT_Zbipe5Wq0Hxgn0S&usqp=CAE",
-        "title": "Nikon D5600 DSLR Camera + AF-P 18-55mm VR + 6pc Graduated Filter - 96GB Bundle ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18-55mm-Lens-Creative-Filter-Set-Bag-SanDisk-Ultra-64GB-Card-6AVE-Electronics-Cleaning-More-International-Mode/252375977?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 44,
-        "price": 445.75,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRfAOEj0SPOUc1KWXRSRFAKouFtZhpkVMKpDFNMIklSYmggAHjVriN2UGjsLj72X1M84I3aZUOsxY7Pz52Lwjg98CkW_h153rSdxsHPovhS4UAyCKjyB4hQ&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + Creative Filter Set ..."
       },
       {
         "extensions": [
@@ -667,233 +511,91 @@ dummy_search_products = {
           "Crop Sensor"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-f-3-5-5-6-Zoom-Lens-32GB-Card-Tripod-Case-and-More-18pc-Bundle/861296170?wmlspartner=wlpa&selectedSellerId=5323",
-        "position": 45,
+        "position": 32,
         "price": 399.0,
-        "rating": 4.5,
-        "reviews": 2030,
+        "product_id": "861296170",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - Als Variety",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQRRQwIxiaTw6Q3a7tjQ3ipQPDf_XBrlEStmjAvZtex8Lp3_ASpXYEPBd6oVsBL5y_6hHNY475N9laQbeClsBem2cNd6GHPEldRPTx32n96&usqp=CAE",
         "title": "Canon Eos 4000D DSLR Camera with 18-55mm f/3.5-5.6 Zoom Lens + 32GB Card, Tripod ..."
       },
       {
         "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-DSLR-Camera-with-18-55mm-Lens-Black/119326570?wmlspartner=wlpa&selectedSellerId=4680",
-        "position": 46,
-        "price": 665.0,
-        "rating": 4.7,
-        "reviews": 583,
-        "source": "Walmart - 33rd Street Camera",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQhsWV0KQfP012P5h6XO9WJBUV3nt8y-vqX1JYllFhyTSSu_I3sthuTAdoWusDXEgkVkJKFRt1W_kuwsbVWxhWtyKUCuREHiRXMUbIlRqtEI3UvUYQ-S3We2Q&usqp=CAE",
-        "title": "Canon Eos Rebel SL3 DSLR Camera with 18-55mm Lens (Black) 3453c002, Size: Large"
-      },
-      {
-        "extensions": [
           "With Video",
           "Crop Sensor"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-f-3-5-5-6-Zoom-Lens-75-300mm-F-4-5-6-III-Lens-32GB-Card-Tripod-Case-and-More-24pc-Bundle/767967970?wmlspartner=wlpa&selectedSellerId=5323",
-        "position": 47,
-        "price": 599.0,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - Als Variety",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcS9viZ0BBZXaL7Bl4RNL0gUflmdPIh66od7GCSpLZVpSQVlUGhB8iMzMFIttgx7LvPGkfDyq-0DLQ6TU3Pl0iRVU-wkpuE5K0ajYXfZDc8D&usqp=CAE",
-        "title": "Canon Eos 4000D DSLR Camera with 18-55mm f/3.5-5.6 Zoom Lens + 75-300mm f/4-5.6 ..."
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18-55mm-Lens-Creative-Filter-Set-Bag-SanDisk-Ultra-64GB-Card-6AVE-Electronics-Cleaning-More-International-Mode/252375977?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 33,
+        "price": 444.6,
+        "product_id": "252375977",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRfAOEj0SPOUc1KWXRSRFAKouFtZhpkVMKpDFNMIklSYmggAHjVriN2UGjsLj72X1M84I3aZUOsxY7Pz52Lwjg98CkW_h153rSdxsHPovhS4UAyCKjyB4hQ&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + Creative Filter Set ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "CMOS",
+          "Wi-Fi"
+        ],
+        "link": "https://www.bestbuy.com/site/nikon-z50-mirrorless-4k-video-camera-with-nikkor-z-dx-16-50mm-f-3-5-6-3-vr-lens-black/6385415.p?skuId=6385415&utm_source=feed",
+        "position": 34,
+        "price": 999.99,
+        "product_id": "6385415",
+        "rating": 4.7,
+        "reviews": 1235,
+        "source": "Best Buy",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSqlBS4fvkCkcl6nNyFTWt_c9Y9ospmRUxP9v99A89yCk68ewHu83JSe8pr1f85JJDT4RbczUbdgoX3UVqPI56IL90HjfIUsyDOzpGw6o21oxiK7mpnV0frmQ&usqp=CAE",
+        "title": "Nikon Z 50 Mirrorless Digital Camera with 16-50mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "Crop Sensor",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-250D-Rebel-SL3-DSLR-Camera-18-55mm-Lens-Black-Creative-Filter-Set-Bag-Sandisk-Ultra-64GB-Card-Electronics-Cleaning-And-More-International-M/786971131?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 35,
+        "price": 629.95,
+        "product_id": "786971131",
+        "rating": 4.6,
+        "reviews": 403,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRMSFKNyhnI6ejo1hjRExohGFJO-JnIuDEuLnQIlf4zeemyVB9aTHhel4UfLw8Eajz1hVQRcmqWLajj8hWX3Smjq4OPcYQkUiv-3kqZWPw00KXyCteoMyWo&usqp=CAE",
+        "title": "Canon Eos 250D / Rebel SL3 DSLR Camera with 18-55mm Lens Black + Creative Filter ..."
       },
       {
         "extensions": [
           "CMOS",
           "With Video",
-          "Black",
-          "$10.00 below typical",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-850D-Rebel-T8iDSLR-Camera-18-55mm-f-4-5-6-IS-STM-Zoom-Lens-75-300mm-F-4-5-6-III-128GB-Card-Filters-2X-Telephoto-Lens-HD-Wide-Angle-Hood-Pou/654517577?wmlspartner=wlpa&selectedSellerId=5323",
+        "position": 36,
+        "price": 1199.0,
+        "product_id": "654517577",
+        "rating": 4.6,
+        "reviews": 255,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSsyXRZ6wLX4E3d7vUECyY4wfJETTtvhPMURWwD5VG3pO6LzP3vG5Xpxkce0kJPR_aTYVk52Wtrb5vBRsHZQAprBkbpM4nInT0NHDYewrib&usqp=CAE",
+        "title": "Canon Eos 850D (Rebel T8i)dslr Camera with 18-55mm f/4-5.6 Is STM Zoom Lens + 75 ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "Crop Sensor",
+          "$19.99 below typical",
           "LOW PRICE"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-with-18-140mm-AF-FX-50mm-Lens-2-Pcs-SanDisk-64GB-Memory-Cards-Tripod-Wideangle-ZeeTech-Accessory-Bundle/720703510?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 48,
-        "price": 1199.99,
-        "rating": 4.6,
-        "reviews": 178,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTyF1JSwbU0q1HlbvclPl6r740MNTUt5ZOyy4p5vWlBC9JY3d3Ey1fEW-pAu-zxD1MjomjHU50BAqAZqvP-r9QZiQokGO-c3gxX2vyRa56o&usqp=CAE",
-        "title": "Great Value Holiday Bundle for D7500 with 18-55mm AFP + 55-300mm VR + Tripod + ..."
-      },
-      {
-        "extensions": [
-          "Detachable Flash",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-Camera-EF-S-18-55-mm-f-3-5-5-6-III-Lens-Pixi-Starter-Bundle-Kit/478479088?wmlspartner=wlpa&selectedSellerId=18065",
-        "position": 49,
-        "price": 399.0,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - BuzzPhoto",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTuvBzEBp7EZk4CfN75z_Gr32xGuNqL6NF3RYxSICq7Wq2TPvGc4BXtQr3okcmwelWByS0UMibUEK-ODVlMd8VVux45VRK-&usqp=CAE",
-        "title": "Canon Eos 4000D DSLR Camera EF-S 18-55 mm f/3.5-5.6 III Lens + Pixi Starter ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-EF-S-18-55mm-Zoom-Lens-SanDisk-64GB-Memory-Card-ZeeTech-Accessory-Bundle/242477159?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 50,
-        "price": 379.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcS4we2KSv4LYQwZzyvmlp0t4qtiFoqp_XoIbKD0YlCyMRCvDQfJRVEdxkwUb8KXXdNkmLI95zsuVU4CTEOsM7C2aMNBFZspIuMggW5gwJHo-baexLis70cxQA&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with EF-S 18-55mm Zoom Lens + SanDisk ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-18MP-DSLR-Camera-with-18-55mm-500mm-Lens-Accessory-Bundle/867727398?wmlspartner=wlpa&selectedSellerId=4831",
-        "position": 51,
-        "price": 486.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - Teds Electronics",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQnfTEopKv0-0a2C7JDHvr3AR0Wf0_fLBSu7IilUwiZ1N90Z0OU-QLw_T01MIEfdpAtes24XEHRxLPUMbA47_yMR_hYRfnj_-0Kk3dy-Thv&usqp=CAE",
-        "title": "Canon Eos 4000D 18MP DSLR Camera + 18-55mm & 500mm Lens Accessory Kit"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-4000D-DSLR-Camera-with-EF-S-18-55mm-Lens-International-Version-64GB-Memory-Card/592043939?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 52,
-        "price": 432.1,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSqdKQVJb0fWX8e_7VEQdtocJhN05u259bhNCNLySLQthu4gXfM0hz2t6SK_vNws5bPh2hmu8L_MmGbziLzE8LVW-8nzFngTLR9N0M7MGMt47BKj-0SPHlc&usqp=CAE",
-        "title": "Canon Eos 4000D DSLR Camera and EF-S 18-55 mm f/3.5-5.6 Is III Lens International ..."
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-Lens-2-Pcs-SanDisk-128GB-Memory-Tripod-Case-ZeeTech-Kit/774407061?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 53,
-        "price": 469.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSxQB4f3DL1U6DeFUVz2PI-HhlPpIAQ3Z3LUcExg2yNfdYj0xcYP2_8J_RE-uUnEL4cm1xcGchnoH1bpPppTlQ1VG9CYr1PgaqZVQF1_FDx&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + 2 Pcs SanDisk 128GB ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D5500-D5600-Digital-SLR-Camera-3-Lens-18-55mm-VR-64GB-Great-Saving-Full-Kit/493230183?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 54,
-        "price": 998.0,
-        "rating": 4.8,
-        "reviews": 2168,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQByPfLWk_8z6eH9D0wLSS8z9NrBEgOUOkEF_MHzWe_a28NmqnhieuLnH7dasYzKvYrbkKX8l_9SHL3yya9nGLn_cH_df0RyEM31vzfpY4&usqp=CAE",
-        "title": "Nikon D5500 Digital SLR Camera +3 Lens 18-55mm VR - 64GB Great Saving Full Kit"
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-Lens-64GB-Card-More-International-Model/854440102?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 55,
-        "price": 497.65,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQPrXO423cwvBlqdUhqTq_yk2TVrVVNusxImDO1xc1liW7ew6frpI8nmeFuPg05QzmVXAjqhIotxLXVL_hTS0ZwZtIAOoHZH0QDnF8Xd2SpMuogtdovCK0ycg&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + 64GB Card + More, Black"
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-with-EF-S-18-55mm-f-3-5-5-6-III-Lens-White-Box/440292034?wmlspartner=wlpa&selectedSellerId=1071",
-        "position": 56,
-        "price": 379.95,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - The Pixel Hub",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTOU8LHwLJglasIQgoiF2ChA4uO-Jv5stGZcWiKqkUamQlFH98SuPORHWv19wtdmnfipw-fvRkAsegf_A9na4gBIeSM3Ldw&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 with EF-S 18-55mm f/3.5-5.6 III Lens - White Box"
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-Zoom-Lens-64GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/482344580?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 57,
-        "price": 414.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRk5EPjNmeIKxJF1W2orR-TiEYZTY_iyo4n4Td1yH9xoNjUX1ZzALLQSgGG9fK69LhAdLhKVRZdjMFS-t6un-5tWhjpAhmNBZAIt2ZdLYWw&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm Zoom Lens + 64GB ..."
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-75-300mm-Lens-32GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/300502118?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 58,
-        "price": 559.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRIIC0WGgeU07VPgm907tAtlcft4NEh92pCl7JErVjxqXTZQoVXMBWBHnWyw8ciQT-1T9gPkeMMGY0I9oR1OPFuxqyoXLzvRT3o-qLCLeji&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm + 75-300mm Lens + ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "CMOS",
-          "Wi-Fi",
-          "SALE"
-        ],
-        "link": "https://www.bestbuy.com/site/fujifilm-x-s10-mirrorless-camera-body-with-xf18-55mmf2-8-4-r-telephoto-lens-black/6440243.p?skuId=6440243&utm_source=feed",
-        "position": 59,
-        "price": 1299.99,
-        "rating": 4.8,
-        "reviews": 585,
-        "source": "Best Buy",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRYza9iqSWRXkFazg54jttGnc2kiE1kBJNwc_EhGL7FEk35Ny4HLUSdW9ofyArNKBFSF01rNRC8Qg3UihjuwsbkIv8pn_FU9DBeiecSiY2z&usqp=CAE",
-        "title": "Fujifilm - X-S10 Mirrorless Camera with 18-55mm Lens"
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
         "link": "https://www.walmart.com/ip/Canon-EOS-4000D-T100-Digital-Camera-EF-S-18-55MM-F-3-5-5-6-III-Lens-EF-75-300mm-f-4-5-6-Telephoto-Zoom-Advanced-Accessories-Bundle/263206743?wmlspartner=wlpa&selectedSellerId=8054",
-        "position": 60,
-        "price": 599.99,
-        "rating": 4.5,
-        "reviews": 2030,
+        "position": 37,
+        "price": 580.0,
+        "product_id": "263206743",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - Deal-Expo",
         "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSsv1_LHmoqnkqoXM6MrsUfOKyC9Wxg2zNWkJTgeJt73ZT_grkagu1qoPtDQZ82iOJN9OKlUZ-c7UbPpEbPqKptD9lsk8JbfQqLMgodgvJQ&usqp=CAE",
         "title": "Canon Eos 4000D / T100 Digital Camera with EF-S 18-55mm f/3.5-5.6 III Lens + ..."
@@ -902,105 +604,240 @@ dummy_search_products = {
         "extensions": [
           "CMOS",
           "With Video",
-          "Black"
+          "Silver"
         ],
-        "link": "https://www.walmart.com/ip/Pentax-K-1-Mark-II-Digital-SLR-Camera-with-28-105mm-Lens/980804191?wmlspartner=wlpa&selectedSellerId=1316",
-        "position": 61,
-        "price": 2096.95,
-        "rating": 4.8,
-        "reviews": 315,
-        "source": "Walmart - Focus Camera",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTQ1BzleqK1s88tMGbbI6d4WzJ3tZeqUZgoNttFUtYtWyrtoKIs3dgbmkveaYx_OGEk7RdTDKvU2SVNviYyxnWvi3zahIfRk8ZN79Uw9hE&usqp=CAE",
-        "title": "Pentax K-1 Mark II DSLR Camera with 28-105mm Lens"
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-Lens-SanDisk-64GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/987684332?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 62,
-        "price": 414.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQCbsuuov1aSlr5j_g9CeqBV1mt99kcXMzCH-6D20SqH30lGfwLYams2azqs-P6YGP_mEmviCE9G_-mUKuSCyRn-AmPdDUF&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm Lens, SanDisk 64GB Memory ..."
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-Lens-SanDisk-32GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/686366102?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 63,
-        "price": 409.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSFawmZpsMm2oC51QOs6jFsj7_GeccJhsKY6mY8lv8Rfp7vwdmkl6bxDefwR85f6DFkIVAQMrjtmzUH3l4oB6Bbr6-FqAERFGUg9LDLKyoA&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm Lens, SanDisk 32GB Memory ..."
-      },
-      {
-        "extensions": [
-          "Crop Sensor",
-          "Black",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-75-300mm-Lens-SanDisk-128GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/311539465?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 64,
-        "price": 589.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcR0YGeQzcUtgdBm7KXcAzkNP1sdRWJOiU_1dtRMJkMZDdfLC4AkFF5OMRNEuO_eJ2jb11sQ0Spiq2H5RxgEynpYu6i_bdzZqj5I8pTxhje8&usqp=CAE",
-        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm, 75-300mm Lens, SanDisk ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-with-EF-S-18-55mm-III-Lens-500mm-1000mm-Bundle/767810186?wmlspartner=wlpa&selectedSellerId=1071",
-        "position": 65,
-        "price": 419.95,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - The Pixel Hub",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTu_usHQ-XikEIov_6ZDTjoK2R1TmsWV62xW8g2cb-HN_fHTdjxNBtMCMAtAuGtfHERbP6KtpJfpbBxlTf3-J1Eu1qc60w91g&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 with EF-S 18-55mm III Lens + 500mm/1000mm Bundle, Black"
+        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-with-18-55mm-VR-Lens-70-300-Lens-64GB-Bundle-Kit/396436556?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 38,
+        "price": 1552.0,
+        "product_id": "396436556",
+        "rating": 4.7,
+        "reviews": 4414,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTIJ3KMi0wPd3E-X5-xaJcdX_MPFsvu0odFykd0Rl02gVhSQxq0lOvRbgudmW4Fm6sLBnAH8y3mdJwacra78IoQ8qxXqWubyd-jWWqV1cQb&usqp=CAE",
+        "title": "Nikon D5600 DSLR Camera with 18-55mm VR Lens + 70-300 Lens + 64GB Bundle Kit"
       },
       {
         "extensions": [
           "With Video",
           "Crop Sensor"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-EF-S-18-55mm-f-3-5-5-6-III-Lens-Starter-Accessory-Bundle-SanDisk-Ultra-64GB-SDXC-Digital-Flash-Extended-Life-Replacement-Battery/441692659?wmlspartner=wlpa&selectedSellerId=5568",
-        "position": 66,
-        "price": 449.95,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - SSE Photo & Video",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRpjjMa8tKpEndMlm8Lzsnt1pJAFwEBwELIndyDINzJKP3csrS6dxfjHrmKIWxkaE0wE4XF53ElNerEWRM75eD0fEBDwFI8&usqp=CAE",
-        "title": "Canon Eos 4000D DSLR with EF-S 18-55mm f/3.5-5.6 III Lens & Starter Accessory ..."
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-f-3-5-5-6-Zoom-Lens-75-300mm-F-4-5-6-III-Lens-32GB-Card-Tripod-Case-and-More-24pc-Bundle/767967970?wmlspartner=wlpa&selectedSellerId=5323",
+        "position": 39,
+        "price": 599.0,
+        "product_id": "767967970",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcS9viZ0BBZXaL7Bl4RNL0gUflmdPIh66od7GCSpLZVpSQVlUGhB8iMzMFIttgx7LvPGkfDyq-0DLQ6TU3Pl0iRVU-wkpuE5K0ajYXfZDc8D&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera with 18-55mm f/3.5-5.6 Zoom Lens + 75-300mm f/4-5.6 ..."
       },
       {
         "extensions": [
           "CMOS",
-          "Crop Sensor",
+          "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-80D-Digital-SLR-Camera-EF-S-18-55mm-f-3-5-5-6-EF-75-300mm-f-4-5-6-III-Dual-Lens-Kit-500mm-Preset-f-8-Telephoto-0-43x-Wide-Angle-2-2x-Pro-Bu/827353971?wmlspartner=wlpa&selectedSellerId=101020459",
-        "position": 67,
-        "price": 1649.0,
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-EF-S-18-55mm-Zoom-Lens-SanDisk-32GB-Memory-Card-ZeeTech-Accessory-Bundle/568398901?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 40,
+        "price": 379.99,
+        "product_id": "568398901",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQkF-iMhJzit0uLT_TH3G28T4F6N5j1PTOzEqbO7mXazRamgQSg3D1ucXuLlbHDqjQSbwHdovIdgffZRI32l0HBoSTF8h8gp3vsyCQyb2zVdlWuF7S0m1pQXQ&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with EF-S 18-55mm Zoom Lens + SanDisk ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-Lens-64GB-Card-More/601136164?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 41,
+        "price": 414.82,
+        "product_id": "601136164",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSahyIhdhzkI4qApkfpfawH1z4nKNh3Zl8BDrai4aLNjWyL8pJYCbwRHGJBU2UAvlgRr46FEJTUC8Z_ftMn9vGZeIYpz99f-7U3dKsuNdZ4-j07FgaiOec7&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + 64GB Card + More, Black"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-Eos-Canon-T7-Digital-SLR-Camera-with-18-55mm-Prime-Lens-Bundle/341489152?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 42,
+        "price": 494.7,
+        "product_id": "341489152",
+        "rating": 4.7,
+        "reviews": 7768,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSGFuEXiCtzYTfoSiFoAdy09xNBmiVQPWFxkE7hJzYOMJhnxU1NKUq9rvEEnjG3KnaEU4AasePu93IdC4pccQfEQSUydc3F&usqp=CAE",
+        "title": "Canon Eos 2000D (Rebel T7) Digital SLR Camera with 18-55mm Prime Lens Bundle"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Bluetooth"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-DSLR-Camera-with-18-55mm-f-4-5-6-IS-STM-Zoom-Lens-32GB-Card-Tripod-Case-and-More-18pc-Bundle/670510200?wmlspartner=wlpa&selectedSellerId=5323",
+        "position": 43,
+        "price": 839.0,
+        "product_id": "670510200",
+        "rating": 4.6,
+        "reviews": 403,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTrINqWG890WDYelLB722FWTJ1Sq3Ggdicygd2FgPBVvzJUUX7K6gGKZfvfnDoZtRGIRVqPetL-I3ohqh6F7UO4WGGdwrJtm8iD5Z-HoJAM&usqp=CAE",
+        "title": "Canon Eos Rebel SL3 DSLR Camera with 18-55mm f/4-5.6 Is STM Zoom Lens + 32GB Card ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black",
+          "SALE"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D500-DX-Format-Digital-SLR-Body-Only-International-Model-No-Warranty/139243435?wmlspartner=wlpa&selectedSellerId=5568",
+        "position": 44,
+        "price": 1539.95,
+        "product_id": "139243435",
         "rating": 4.8,
-        "reviews": 4426,
-        "source": "Walmart - Babushkas Market",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSi1vVZ2lzPJyVvoOci0MDZMQS8_TJerIVT5VMB-p5Gu8zZxq3A5ZtYlS1QlS2GF2XI63LwAofPOzxiyCBLf1I_v-jDMU1e8-fE01YvpyGd&usqp=CAE",
-        "title": "Canon Eos 80D Digital SLR Camera with EF-S 18-55mm f/3.5-5.6 + EF 75-300mm f/4-5 ..."
+        "reviews": 2708,
+        "source": "Walmart - SSE Photo & Video",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQpiB_9O_KAZ8O-opHZTV5WEZ8QgX3TRn2MqjKsm1uRq3cdAEYdh5kUeLeB4JSnW5f5rBWvJRYyBPSyMdV6bYEaGPand-nEPOGSz7spVVZ7DFqfttFpzdYa&usqp=CAE",
+        "title": "Nikon D500 DX-Format Digital SLR (Body Only)"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-250D-DSLR-Camera-with-EF-S-18-55mm-f-4-5-6-IS-STM-Lens-Black/387804811?wmlspartner=wlpa&selectedSellerId=5568",
+        "position": 45,
+        "price": 649.95,
+        "product_id": "387804811",
+        "rating": 4.7,
+        "reviews": 1137,
+        "source": "Walmart - SSE Photo & Video",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQAAdtxVtLic-Gr-VfUEHZRvKTkBxnt0qSygNUo5ooK0fRkQAm_CgH3SrXvnHJHzl_HE8mAdW7qnM6VDQs5ScKt-UFOBlayjQpQOCZyqyUefwcJgNR1oe8C&usqp=CAE",
+        "title": "Canon Eos 250D Kit EF-S 18-55mm STM (Black)"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D5600-DSLR-Camera-AF-P-18-55mm-VR-6PC-Graduated-Filter-96GB-Bundle/601274947?wmlspartner=wlpa&selectedSellerId=441",
+        "position": 46,
+        "price": 1089.99,
+        "product_id": "601274947",
+        "rating": 4.7,
+        "reviews": 4414,
+        "source": "Walmart - Tri State Camera",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQANnl-QRIyIPmu13BNjpgf2i3pfqrhpyLOESaJCRl9-EUdnyJ0F28QeZHxiyIAhdyr0LuBIyYvHx62ixQNbMArGPekMm6Ez03DuMgT_Zbipe5Wq0Hxgn0S&usqp=CAE",
+        "title": "Nikon D5600 DSLR Camera + AF-P 18-55mm VR + 6pc Graduated Filter - 96GB Bundle ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-Digital-SLR-Camera-with-18-55mm-Lens-Kit-18-Megapixel-Sensor-Wi-Fi-DIGIC4-SanDisk-32GB-Memory-Card-and-Live-View-Shooting/771229626?wmlspartner=wlpa&selectedSellerId=101468958",
+        "position": 47,
+        "price": 364.0,
+        "product_id": "771229626",
+        "rating": 4.3,
+        "reviews": 236,
+        "source": "Walmart - sals electronics",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTS76vegDCmBYtp7ozV2sPnAXGN2EA97884jspO2hm8tG6_657YSFotCDs1BG2ojEkrC4tUuVrCkJANoO9czVrAWQaNzBEw7VNHsux05xfDZgqq6ErgbHtmMQ&usqp=CAE",
+        "title": "Canon Eos Rebel T100 DSLR Camera with 18-55mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-4000D-DSLR-Camera-with-EF-S-18-55mm-Lens-International-Version-64GB-Memory-Card/592043939?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 48,
+        "price": 432.12,
+        "product_id": "592043939",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSkfO5cGlZe3ET1xeD2OaEXIsNP1PCzpUTAcGJtEZOJvaLDekvdaM9fOCn67kV4OfjUOEWgTKZQiS88LW1xLG4AvPcHr-fiZo2FIOCVlmU&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera and EF-S 18-55 mm f/3.5-5.6 Is III Lens International ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-w-EF-S-18-55mm-F-3-5-5-6-Zoom-Lens-32GB-Memory-Case-Tripod-Filters-20pc-Bundle/671602495?wmlspartner=wlpa&selectedSellerId=5323",
+        "position": 49,
+        "price": 419.0,
+        "product_id": "671602495",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSRzBUHKdJuJFkjWXPDtE341p_xprcagbJrFiRWOjEB-mW1Dn0VAJ6u-bk0hC9ghkwAzAfV17kcMhxuvy-i-sSCJVROSJ0lNw&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera w/EF-S 18-55mm f/3.5-5.6 Zoom Lens + ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-18MP-with-EF-S-18-55mm-Zoom-Lens-SanDisk-64GB-Memory-Card-Tripod-ZeeTech-Accessory-Bundle/613308159?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 50,
+        "price": 379.99,
+        "product_id": "613308159",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcToA2Zs4TIJV316pbHjaVEtQEVwJQ_gVeIQmQf5rEf97r5eL-91VtFlW1aUXDZGIVVhCsnRKGdblRnvRiFTY9Y_mfkXnDssbzfVC_gW0NmD&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera 18MP with EF-S 18-55mm Zoom Lens + ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-EF-S-18-55mm-Zoom-Lens-SanDisk-64GB-Memory-Card-ZeeTech-Accessory-Bundle/242477159?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 51,
+        "price": 379.99,
+        "product_id": "242477159",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcS4we2KSv4LYQwZzyvmlp0t4qtiFoqp_XoIbKD0YlCyMRCvDQfJRVEdxkwUb8KXXdNkmLI95zsuVU4CTEOsM7C2aMNBFZspIuMggW5gwJHo-baexLis70cxQA&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with EF-S 18-55mm Zoom Lens + SanDisk ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-Lens-2-Pcs-SanDisk-32GB-Memory-Tripod-Case-ZeeTech-Kit/249326338?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 52,
+        "price": 439.99,
+        "product_id": "249326338",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcR6lTjHbPk_pcmWYdgZwwzYBurDUufrA837pXg3p_liavski3rBcRDw9CqMhIfZAyB43oBDZVUX-L-izDdOdku4wdW7F-8hx4cS6m4YsbY&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + 2 Pcs SanDisk 32GB ..."
       },
       {
         "extensions": [
@@ -1009,10 +846,11 @@ dummy_search_products = {
           "Wi-Fi"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-75-300mm-Lens-SanDisk-32GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/303773518?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 68,
+        "position": 53,
         "price": 564.99,
-        "rating": 4.5,
-        "reviews": 2030,
+        "product_id": "303773518",
+        "rating": 4.6,
+        "reviews": 2094,
         "source": "Walmart - JumboBuys",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRqcpmPU8DkMvElFkFBjytld8UM-VEeZ1ulZUSRVtvZ5oVvv0voy2ThZK_wJ_BV8nYcURxV-kTQba3yztITTTEAgl4lYnJ9eOvbti_npEw&usqp=CAE",
         "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm, 75-300mm Lens, SanDisk ..."
@@ -1023,107 +861,61 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24-2-MP-Digital-SLR-Camera-18-55mm-Lens-with-Deluxe-Accessory-Kit/150850924?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 69,
-        "price": 896.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTiOircAzW8rAIT2Xw-e88ufm0GriZeLV3d5wAcXNIadrX59qc4qNoOUzjZL8itIRUVwdW6_iYtP7JrOx5hM_-YFAwARovtVzMEr-185EA&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - 32 GB ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
         "link": "https://www.walmart.com/ip/Canon-EOS-3000D-T100-DSLR-Camera-Black-with-18-55mm-III-Lens/416746986?wmlspartner=wlpa&selectedSellerId=8054",
-        "position": 70,
+        "position": 54,
         "price": 339.99,
+        "product_id": "416746986",
         "rating": 4.8,
-        "reviews": 198,
+        "reviews": 272,
         "source": "Walmart - Deal-Expo",
         "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTI5xikhXhY5UM2G-QOdb7iwEZo_BLldm85fxAb8hCW8IFj9InWSYvqYmIcjlaVlNPwBUVEBOMChzr5oB5lFRSgwWn6sW-J5zIgVEUYOkQ&usqp=CAE",
         "title": "Canon Eos 3000D with EF-S 18-55mm III Lens"
       },
       {
         "extensions": [
-          "CMOS",
-          "With Video",
-          "Red",
-          "Wi-Fi",
-          "$56.45 below typical",
-          "LOW PRICE"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3300-D3500-DSLR-Camera-with-18-55mm-Lens-Nikon-55-200mm-VR-Lens-Nikon-WU-1A-Sandisk-32GB-Flash-More/49583143?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 71,
-        "price": 1072.55,
-        "rating": 4.7,
-        "reviews": 5364,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTsIS9X8ZlTO08E8R_6rEGe0psPKFVMgXkg-QP_NwqEPpPe55DsezVGSlBkveXPRYBn-Z1azC1hnuMGt8UYLDRiuXdmJEbYcSnN4WyRcwg&usqp=CAE",
-        "title": "Nikon D3300 Digital SLR Camera & 18-55mm (Red) & 55-200mm VR II Lens"
-      },
-      {
-        "extensions": [
-          "CMOS",
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D7100-DSLR-Camera-Nikon-18-55mm-Lens-500mm-Telephoto-Lens-32GB-Kit/229049798?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 72,
-        "price": 1399.0,
-        "rating": 4.8,
-        "reviews": 3669,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcS8U5yGd1yaOLe7J7o4EgrusGuRilzKaUR7NBzDNwnW1oPKbsPvlXtecvhRyJrPMBZlnvtyc-kw_0GX01nmsxJOEAblJMZPkcB6f5ZaeHCd-GgB1e-YE8zb2A&usqp=CAE",
-        "title": "Nikon D7100 DSLR Camera + Nikon 18-55mm Lens + 500mm Telephoto Lens - 32GB Kit ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Pentax-KF-DSLR-Camera-Body-Black/1917651173?wmlspartner=wlpa&selectedSellerId=1316",
-        "position": 73,
-        "price": 696.95,
-        "rating": 4.5,
-        "reviews": 11,
-        "source": "Walmart - Focus Camera",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQ-z3_eVuaY0RSi59HZFEl1xLHoLt7LgtJkhdEWRNW05No12NXfxHO31fBDJrOY65qL9Z3WyCxECO1oIhRy7kcx0_2yTV59SDbaocqZi0246vvO4sKjIUPd&usqp=CAE",
-        "title": "Pentax KF DSLR Camera Body (Black)"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-DSLR-Camera-Black-with-18-55mm-and-70-300mm-VR-Lenses-32GB-Kit/165648463?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 74,
-        "price": 1296.0,
+        "link": "https://www.walmart.com/ip/Nikon-D3500-DSLR-Camera-with-18-55mm-Lens-64GB-Bundle/268742803?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 55,
+        "price": 1298.0,
+        "product_id": "268742803",
         "rating": 4.7,
-        "reviews": 7323,
+        "reviews": 4066,
         "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcQyAyvOgH2rJjb_8nLuBpH-F0wPOZWswlsrTicyM3qLyuCoGSs7zxI_XJbUcXR76GgeX2BJD_mNcavtkmFF-lVFazr-IawrmMdL0zWUN_0CRH6YxgqCaidq&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR and 70-300mm ..."
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRT1UXJbAOCMsEmwZKBTy0ryFb-qo1LVrUdiWsPnhFD1zC79Kr7HSPAhZQY22tdiCeAmmB_UKKyRHNJdXTDmFVp10R-2sJ6SDvhfHgqrPw&usqp=CAE",
+        "title": "Nikon D3500 DSLR Camera with 18-55mm Lens & 64GB Bundle, Black"
       },
       {
         "extensions": [
-          "CMOS",
-          "Crop Sensor",
-          "Wi-Fi"
+          "With Video",
+          "Crop Sensor"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-with-18-55mm-VR-Lens-128GB-Card-Tripod-Flash-ALS-Variety-Lens-Cloth-and-More/993692664?wmlspartner=wlpa&selectedSellerId=5323",
-        "position": 75,
-        "price": 1249.0,
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-18-Megapixel-Digital-SLR-Camera-with-Lens-0-71-2-17-Black/820481078?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 56,
+        "price": 470.13,
+        "product_id": "820481078",
         "rating": 4.6,
-        "reviews": 178,
-        "source": "Walmart - Als Variety",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQMb5FPHRozHYN34wq6eOwwce_yws9nvMy7fdjoqa-WfhVjpcmV1ADWg6xoCbj9dXj0IhLUy2inpOSGlQxw549FCnBJD3M9QAFy0euSn5k&usqp=CAE",
-        "title": "Nikon D7500 DSLR Camera with 18-55mm VR Lens + 128GB Card, Tripod, Flash, ALS ..."
+        "reviews": 2094,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQUA7eoobBp-zGvw5b3H0jVeaSpRfQ3N6Y6YWP26yNDl4cGpLgVOz2PnCs5VxmZzX_3vn2vFRq1nGzaA1BckW46-rG8svvNLWEEuGSPwC6WLKOrLj2DKKwDiQ&usqp=CAE",
+        "title": "Canon Eos Rebel 4000D Digital SLR Camera with EF-S 18-55mm f/3.5-5.6 DC III Lens ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-DSLR-Camera-with-18-55mm-Lens-EF-75-300mm-More/525902527?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 57,
+        "price": 669.95,
+        "product_id": "525902527",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSlxNriHGzEUoy2TTrm5W85GJgx9X6IcsZ_L1qyCzD-l2nSxJ5KT7tYZ7WAjH5B0cOQAwkCtqD7dSRobPO5HP0_Em4tLj6AJhX2_81FdAvBBzDcEFk-kUkjQg&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 DSLR Camera with 18-55mm Lens + EF 75-300mm + More"
       },
       {
         "extensions": [
@@ -1131,14 +923,15 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T7i-24-2-Megapixel-Digital-SLR-Camera-with-Lens-0-71-2-17/404019774?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 76,
-        "price": 1343.45,
-        "rating": 4.8,
-        "reviews": 2964,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcRllYrqinCXKNSwX5BLahSEzlNJka87ITchOElN1wRDv8mL0_YEDmj8qU8Y568E_YFvkkHuVIk-iHOGgvNdU_uVn8MlaHkdDcAaaGCw_SM&usqp=CAE",
-        "title": "Canon Eos Rebel T7i DSLR Camera with 18-55mm Lens"
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-Digital-SLR-Camera-18-55mm-Lens-3453C002-Professional-package-deal-Bundle-SanDisk-32gb-SD-Card-3PC-Filter-Kit-57-Tripod-MORE/209419099?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 58,
+        "price": 714.95,
+        "product_id": "209419099",
+        "rating": 4.6,
+        "reviews": 403,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcR1fKHRKvr1dPyl_op94llSxF-kQE4Fw4qvSaJc3J4wS5AJBvPWp_1ruz4dQ2zJluhrUUoWihdgqy46mOz6t-ztG4BDRcqm1Ua661o9HbuR1PPDCI4-TT5I&usqp=CAE",
+        "title": "Canon Eos Rebel SL3 Digital SLR Camera with 18-55mm Lens (3453C002) Professional ..."
       },
       {
         "extensions": [
@@ -1147,14 +940,301 @@ dummy_search_products = {
           "Black",
           "SALE"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-7D-Mark-II-DSLR-Camera-Body-Only/350654363?wmlspartner=wlpa&selectedSellerId=8054",
-        "position": 77,
-        "price": 1999.0,
+        "link": "https://www.walmart.com/ip/Nikon-D500-20-9-Megapixel-Digital-SLR-Camera-with-Lens-7-87-19-69-Black/111532611?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 59,
+        "price": 3878.06,
+        "product_id": "111532611",
         "rating": 4.8,
-        "reviews": 2138,
-        "source": "Walmart - Deal-Expo",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRpSWDXkWkxsVboCe_Fpro_Ysij60T_6TGSeiZkfGzdC9WO4eoBIJux2xhr7km9y0lmRlM8DSRB2uu00-akp-tRdQasbe98k4n31PgiIkI&usqp=CAE",
-        "title": "Canon Eos 7D Mark II Body"
+        "reviews": 2708,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR4AA91qnG1HLfK0jSFlmruCLZNOH6LZ6oS_LO-D3uH2NAbMx1cObj4sd-q_FKYTz5AItEQ3uizveSE6gxDiWAzDWTTKaIKgzZGlg2rqFmBXc0XBEEslGGP&usqp=CAE",
+        "title": "Nikon D500 DSLR Camera Sports and Wildlife Kit"
+      },
+      {
+        "extensions": [
+          "With Video",
+          "Crop Sensor"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Digital-Camera-with-EF-S-18-55MM-F-3-5-5-6-III-Lens-Basic-Accessories-Bundle/827707876?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 60,
+        "price": 379.0,
+        "product_id": "827707876",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTJCZuGQPZ_neOJKxr8Cg_XZrmLrELc1091ID9FOenBY-J1EZO__GvIFiomUx8F9LANAIRx7nS_Dn3XViI6Ic-qPMKIeNQV_fKtDn_GTLc&usqp=CAE",
+        "title": "Canon Eos 4000D Digital Camera with EF-S 18-55mm f/3.5-5.6 III Lens + Basic ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-with-EF-S-18-55mm-III-Lens-500mm-1000mm-Bundle/767810186?wmlspartner=wlpa&selectedSellerId=1071",
+        "position": 61,
+        "price": 419.95,
+        "product_id": "767810186",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - The Pixel Hub",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTu_usHQ-XikEIov_6ZDTjoK2R1TmsWV62xW8g2cb-HN_fHTdjxNBtMCMAtAuGtfHERbP6KtpJfpbBxlTf3-J1Eu1qc60w91g&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 with EF-S 18-55mm III Lens + 500mm/1000mm Bundle, Black"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-Lens-SanDisk-128GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/535268164?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 62,
+        "price": 439.99,
+        "product_id": "535268164",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTMRbjpLuZeMh4qsjnnS1MCG0z_Ilm2cvaYUzwbRWyvkkOt9f5ivdu8Xs7AtZCycPfewvrPjqXI2JkGU8r3qsrRPXTurBiFdbqUG3kUcqc&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm Lens, SanDisk 128GB Memory ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL3-DSLR-Camera-with-18-55mm-Lens-Black/119326570?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 63,
+        "price": 599.95,
+        "product_id": "119326570",
+        "rating": 4.6,
+        "reviews": 403,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQhsWV0KQfP012P5h6XO9WJBUV3nt8y-vqX1JYllFhyTSSu_I3sthuTAdoWusDXEgkVkJKFRt1W_kuwsbVWxhWtyKUCuREHiRXMUbIlRqtEI3UvUYQ-S3We2Q&usqp=CAE",
+        "title": "Canon Eos Rebel SL3 DSLR Camera with 18-55mm Lens (Black) 3453c002, Size: Large"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-Camera-EF-S-18-55-mm-f-3-5-5-6-III-Lens-Buzz-photo-Starter-Bundle-Kit/533550276?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 64,
+        "price": 379.0,
+        "product_id": "533550276",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQUO8tO2wwOBi-a9nglHckR1EOsDlp7Vwvd40af1cORgJl2hgFdmaI_v9-nVwX9F5tFGkPl0wvXkaU3cWEhyYnXMlMjaY2f&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera EF-S 18-55 mm f/3.5-5.6 III Lens + Buzz-Photo Starter ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "Crop Sensor"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-18MP-DSLR-Camera-with-18-55mm-500mm-Lens-Accessory-Bundle/867727398?wmlspartner=wlpa&selectedSellerId=4831",
+        "position": 65,
+        "price": 486.99,
+        "product_id": "867727398",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Teds Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQnfTEopKv0-0a2C7JDHvr3AR0Wf0_fLBSu7IilUwiZ1N90Z0OU-QLw_T01MIEfdpAtes24XEHRxLPUMbA47_yMR_hYRfnj_-0Kk3dy-Thv&usqp=CAE",
+        "title": "Canon Eos 4000D 18MP DSLR Camera + 18-55mm & 500mm Lens Accessory Kit"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Pentax-KF-DSLR-Camera-Body-Black/1917651173?wmlspartner=wlpa&selectedSellerId=1316",
+        "position": 66,
+        "price": 696.95,
+        "product_id": "1917651173",
+        "rating": 4.3,
+        "reviews": 3,
+        "source": "Walmart - Focus Camera",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQ-z3_eVuaY0RSi59HZFEl1xLHoLt7LgtJkhdEWRNW05No12NXfxHO31fBDJrOY65qL9Z3WyCxECO1oIhRy7kcx0_2yTV59SDbaocqZi0246vvO4sKjIUPd&usqp=CAE",
+        "title": "Pentax KF DSLR Camera Body (Black)"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-Lens-SanDisk-64GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/987684332?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 67,
+        "price": 414.99,
+        "product_id": "987684332",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQCbsuuov1aSlr5j_g9CeqBV1mt99kcXMzCH-6D20SqH30lGfwLYams2azqs-P6YGP_mEmviCE9G_-mUKuSCyRn-AmPdDUF&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm Lens, SanDisk 64GB Memory ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Pentax-K-1-Mark-II-Digital-SLR-Camera-with-28-105mm-Lens/980804191?wmlspartner=wlpa&selectedSellerId=1316",
+        "position": 68,
+        "price": 2096.95,
+        "product_id": "980804191",
+        "rating": 4.8,
+        "reviews": 316,
+        "source": "Walmart - Focus Camera",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTQ1BzleqK1s88tMGbbI6d4WzJ3tZeqUZgoNttFUtYtWyrtoKIs3dgbmkveaYx_OGEk7RdTDKvU2SVNviYyxnWvi3zahIfRk8ZN79Uw9hE&usqp=CAE",
+        "title": "Pentax K-1 Mark II DSLR Camera with 28-105mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D5500-D5600-Digital-SLR-Camera-3-Lens-18-55mm-VR-64GB-Great-Saving-Full-Kit/493230183?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 69,
+        "price": 998.0,
+        "product_id": "493230183",
+        "rating": 4.8,
+        "reviews": 2172,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQByPfLWk_8z6eH9D0wLSS8z9NrBEgOUOkEF_MHzWe_a28NmqnhieuLnH7dasYzKvYrbkKX8l_9SHL3yya9nGLn_cH_df0RyEM31vzfpY4&usqp=CAE",
+        "title": "Nikon D5500 Digital SLR Camera +3 Lens 18-55mm VR - 64GB Great Saving Full Kit"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-1300D-18MP-DSLR-Camera-18-55mm-Lens/106897886?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 70,
+        "price": 424.0,
+        "product_id": "106897886",
+        "rating": 4.8,
+        "reviews": 9113,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSHHubhHDvcoaiAF77_1NJVseDrwLtAQrTBhb92_MDbzZoUMdtgvl5sAeH02CV6rCLfef_dcPZJ77o4N-DSu481vkV2LfPdI5KP6N94YaS6JaD8nfN8cR2w6A&usqp=CAE",
+        "title": "Canon EOS Rebel T6 18.0 MP Digital SLR Camera - Black - 18-55mm Lens"
+      },
+      {
+        "extensions": [
+          "Full Frame Sensor",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/K-1-Mark-II-DSLR-Camera-with-21mm-f-2-4-Lens/1896819510?wmlspartner=wlpa&selectedSellerId=6907",
+        "position": 71,
+        "price": 3092.95,
+        "product_id": "1896819510",
+        "rating": 4.8,
+        "reviews": 316,
+        "source": "Walmart - Adorama Camera",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQu4egwHZ4BHokw4dAdobxbaUBbUN9kS5ivHrg8ZCzvKLCtY2SQDMF8MYizZk0j6xvpGZusrgFe8QVDveQ1Frqw2ue5-W1DaSKUV9e_Zey23mgEKFCnQ2GG0g&usqp=CAE",
+        "title": "Pentax K-1 Mark II DSLR Camera with 21mm f/2.4 Lens"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-with-18-55mm-75-300mm-Lens-SanDisk-128GB-Memory-Tripod-Backpack-and-ZeeTech-Bundle/311539465?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 72,
+        "price": 589.99,
+        "product_id": "311539465",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcR0YGeQzcUtgdBm7KXcAzkNP1sdRWJOiU_1dtRMJkMZDdfLC4AkFF5OMRNEuO_eJ2jb11sQ0Spiq2H5RxgEynpYu6i_bdzZqj5I8pTxhje8&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera with 18-55mm, 75-300mm Lens, SanDisk ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "CMOS",
+          "Wi-Fi",
+          "SALE"
+        ],
+        "link": "https://www.bestbuy.com/site/fujifilm-x-s10-mirrorless-camera-body-with-xf18-55mmf2-8-4-r-telephoto-lens-black/6440243.p?skuId=6440243&utm_source=feed",
+        "position": 73,
+        "price": 1299.99,
+        "product_id": "6440243",
+        "rating": 4.8,
+        "reviews": 499,
+        "source": "Best Buy",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRYza9iqSWRXkFazg54jttGnc2kiE1kBJNwc_EhGL7FEk35Ny4HLUSdW9ofyArNKBFSF01rNRC8Qg3UihjuwsbkIv8pn_FU9DBeiecSiY2z&usqp=CAE",
+        "title": "Fujifilm - X-S10 Mirrorless Camera with 18-55mm Lens"
+      },
+      {
+        "extensions": [
+          "Detachable Flash",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-Camera-EF-S-18-55-mm-f-3-5-5-6-III-Lens-Pixi-Starter-Bundle-Kit/478479088?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 74,
+        "price": 379.0,
+        "product_id": "478479088",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTuvBzEBp7EZk4CfN75z_Gr32xGuNqL6NF3RYxSICq7Wq2TPvGc4BXtQr3okcmwelWByS0UMibUEK-ODVlMd8VVux45VRK-&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera EF-S 18-55 mm f/3.5-5.6 III Lens + Pixi Starter ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-75-300mm-Lens-128GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/333235693?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 75,
+        "price": 579.99,
+        "product_id": "333235693",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTSP2W7jyqRqeTLdvtBgHb-3IswmCPxxRAqP_498BViAmG3H_d_jOoShjxfuI7Bns5dXw0Ku163Il4nIyI4EPPnsuFa4SQqnhwE81CdXPXx&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm + 75-300mm Lens + ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-Zoom-Lens-64GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/482344580?wmlspartner=wlpa&selectedSellerId=6558",
+        "position": 76,
+        "price": 414.99,
+        "product_id": "482344580",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRk5EPjNmeIKxJF1W2orR-TiEYZTY_iyo4n4Td1yH9xoNjUX1ZzALLQSgGG9fK69LhAdLhKVRZdjMFS-t6un-5tWhjpAhmNBZAIt2ZdLYWw&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm Zoom Lens + 64GB ..."
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi",
+          "$25.00 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-4000D-DSLR-Camera-18-55mm-Lens-Wi-Fi-New-Pro-Accessory-Bundle/412444510?wmlspartner=wlpa&selectedSellerId=13139",
+        "position": 77,
+        "price": 394.0,
+        "product_id": "412444510",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - Paging Zone Inc.",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRnOTd57m-dUheaLHJyHGLGdjGoAqT1BDPwmHVj4zvXl0i2xDw-YEj73EI6wQfOZo1JLlDpS9utggT2lXFDJlkfRQOxgJUR8ymQc44eoD8&usqp=CAE",
+        "title": "Canon Eos 4000D DSLR Camera with 18-55mm f/3.5-5.6 III + Professional Accessory ..."
       },
       {
         "extensions": [
@@ -1165,8 +1245,9 @@ dummy_search_products = {
         "link": "https://www.walmart.com/ip/Nikon-D5300-DSLR-Camera-with-18-55mm-Lens-Black/452230118?wmlspartner=wlpa&selectedSellerId=6811",
         "position": 78,
         "price": 994.0,
+        "product_id": "452230118",
         "rating": 4.7,
-        "reviews": 4575,
+        "reviews": 4714,
         "source": "Walmart - BuyDirect & Save",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQP_cvHIVHd4l1UyQC7fezHzutlosGHIIyopOIta7VjJjxIJUvT7gnMHh_yemyvE3UfI6UIYh3gLblHA6TTIoHoW5ozsnLiGe0D8ObHOkoQ&usqp=CAE",
         "title": "Nikon D5300 Digital SLR Camera - Black (24.2 MP, AF-P 18-55mm VR Lens"
@@ -1177,43 +1258,15 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-DSLR-Camera-18-55mm-VR-3-Lens-Kit-Flash-1yr-Warranty-64GB/812277089?wmlspartner=wlpa&selectedSellerId=6811",
+        "link": "https://www.walmart.com/ip/Canon-EOS-2000D-Rebel-T7-DSLR-Camera-18-55mm-III-Kit-Intl-Model/900869799?wmlspartner=wlpa&selectedSellerId=4720",
         "position": 79,
-        "price": 965.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSERC8C67NCRr6uzCRI7V2yKKnOD_vxiWxvtuPSCR6F3E48LKoMgnZr-LowZL1WiSADtVjoY2ejzLB2tUQXYaQlqK_WSzKfudcXrfRd6ipRfCDYbO86AhT02A&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR - 3 Lens and ..."
-      },
-      {
-        "extensions": [
-          "Full Frame Sensor",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/K-1-Mark-II-DSLR-Camera-with-21mm-f-2-4-Lens/1896819510?wmlspartner=wlpa&selectedSellerId=6907",
-        "position": 80,
-        "price": 3092.95,
-        "rating": 4.8,
-        "reviews": 315,
-        "source": "Walmart - Adorama Camera",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQu4egwHZ4BHokw4dAdobxbaUBbUN9kS5ivHrg8ZCzvKLCtY2SQDMF8MYizZk0j6xvpGZusrgFe8QVDveQ1Frqw2ue5-W1DaSKUV9e_Zey23mgEKFCnQ2GG0g&usqp=CAE",
-        "title": "Pentax K-1 Mark II DSLR Camera with 21mm f/2.4 Lens"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24MP-Digital-SLR-Camera-18-55mm-Lens-32GB-Great-Value-Kit/759051775?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 81,
-        "price": 988.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQKIkUSiik5Hgg4kCGBQrSgAirgnOvoHP9_yYqRXjUuF-cGAry1mt6otJ7N2dKqeVZM3Plo2em6-XGtvD8AS56Cr1D_bOeFOhE7zk9WNELiaFDjhLrPNpfK&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - 32 GB ..."
+        "price": 381.13,
+        "product_id": "900869799",
+        "rating": 4.6,
+        "reviews": 2641,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSF8gwrWsTxtFo-9u-fKQLW59TztuFXjRyOIcYUD1Ff9Bikm7aP-2JwVvxQd3DWErOvont3TOnXt8Tz5PK8vD6LrqL5zB_OXe5tyvwxf54kiCJxggnJOJTX&usqp=CAE",
+        "title": "Canon Eos 2000D (Rebel T7) DSLR Camera + 18-55mm III Kit"
       },
       {
         "extensions": [
@@ -1222,27 +1275,46 @@ dummy_search_products = {
           "Black"
         ],
         "link": "https://www.walmart.com/ip/Nikon-D3400-D3500-DSLR-Camera-with-18-55mm-Lens-Black-Sigma-70-300mm-SLD-DG-Lens-Package-Black-Bundle-64GB-SDXC-Memory-Card-Supreme-Bundle/136243034?wmlspartner=wlpa&selectedSellerId=932",
-        "position": 82,
+        "position": 80,
         "price": 1199.0,
+        "product_id": "136243034",
         "rating": 4.7,
-        "reviews": 7323,
+        "reviews": 3995,
         "source": "Walmart - OneStopShop",
         "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQHU_oFXrkmZbb93tWJLTSo2ibK3EzEDpR-nTEkpcPFE2_z7_31Ko6Gx_qz0O5gmtPLjIrxR_64wi__BnhJu5A0rUwscqDdsgSTl-AzzzMaCWRqHHh4nYdsDg&usqp=CAE",
         "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR and 70-300mm ..."
       },
       {
         "extensions": [
-          "Black",
-          "Bluetooth"
+          "CMOS",
+          "With Video",
+          "White"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24-2-MP-Digital-SLR-Camera-Black-AF-P-DX-18-55mm-VR-and-70-300mm-Lenses-30-piece-Accessory-Bundle/746627998?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 83,
-        "price": 1194.0,
-        "rating": 4.7,
-        "reviews": 7323,
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-Digital-SLR-Camera-18-55mm-and-75-300mm-Zoom-Lenses-International-Model-No-Warranty/235540697?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 81,
+        "price": 829.95,
+        "product_id": "235540697",
+        "rating": 4.8,
+        "reviews": 9113,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcR9OSLCorJh6N2ts8-zMMoVM-UzqDIWbFB8EYsvRqpsohpx2MQXH4yG5haN3CPeapV6Jx9MMlPyBH6hcfFk57aiKardctr5Qg&usqp=CAE",
+        "title": "Canon Eos Rebel T6 Digital SLR Camera 18-55mm and 75-300mm Zoom Lenses"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D7200-D7500-DSLR-Camera-with-18-140mm-Prime-Lens-Nikon-50mm-1-8G-Lenses-Bundle/422515527?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 82,
+        "price": 1490.0,
+        "product_id": "422515527",
+        "rating": 4.8,
+        "reviews": 2336,
         "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQCfMKTWWUYa3JiypmW2hRaAVDum7lRttITaOE1r1BCCXz-rBCVWYPsnFfW8-GTYtG3N0_0CqDHmwpruvROndu4wjpPKGQr&usqp=CAE",
-        "title": "Nikon D3400 24.2 Mp Digital SLR Camera - Black - AF-P DX 18-55mm VR and 70-300mm ..."
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSv_ZC1FHSwjKeKFabABiJQA5kDlLtRARst1pl6_pxwB61G3U2AdRZsmaSOQAyts-GhPLpgNwrmx_IvMzGqd3bao2JdDVPNyTrJj12fFV8sp-QChaZxxepYTg&usqp=CAE",
+        "title": "Nikon D7200 DSLR Camera with 18-140mm Prime Lens Kit"
       },
       {
         "extensions": [
@@ -1250,14 +1322,47 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24MP-Digital-SLR-Camera-52mm-UV-Filter-Top-Value-Accessory-Kit/185621675?wmlspartner=wlpa&selectedSellerId=6811",
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-Digital-SLR-Camera-Kit-with-EF-S-18-55mm-f-3-5-5-6-DC-III-Lens-Black/261932419?wmlspartner=wlpa&selectedSellerId=4720",
+        "position": 83,
+        "price": 609.95,
+        "product_id": "261932419",
+        "rating": 4.8,
+        "reviews": 9113,
+        "source": "Walmart - 6AVE Electronics",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTpjMgwTsX6sjesRczUpKBF9UTzdgNcV37EYXKwyESM9cUsF3eVM40IhLGM6R_6FxJ4evRqL50dXwcsRKpyS39GTK6YdBQnpTiUznQqaGzhHApch0oFW1VETg&usqp=CAE",
+        "title": "Canon EOS Rebel T6 18.0 MP Digital SLR Camera - Black - EF-S 18-55mm DC III Lens"
+      },
+      {
+        "extensions": [
+          "Crop Sensor",
+          "Black",
+          "Wi-Fi"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-4000D-DSLR-Camera-Bundle-with-18-55mm-75-300mm-Lens-64GB-SanDisk-Card-Case-Tripod-ZeeTech-Accessory/843427047?wmlspartner=wlpa&selectedSellerId=6558",
         "position": 84,
-        "price": 947.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSjLwaayQqlLkJmdUXgVXEpWPFCzViXQEQYUObqSsNCDod4NUBqORuWQkpH1CFrMN5-xKtKxu-lrYhtDprft_78QTo7VQrOly4RJMb7uNxjLoCwt_7u4OMZRg&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - Top ..."
+        "price": 574.99,
+        "product_id": "843427047",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcTpySOO0PdQ3Mdx-p4TXVcDlZaEQU8PXbW1stw5vtRu4rFoFj4dbQ7J5Cg2NYGI5xbriPnimtCiMLT_niKd1yDEJqZemXrN0XznuHO3E6Gq&usqp=CAE",
+        "title": "Canon Eos Rebel T100 / 4000D DSLR Camera Bundle with 18-55mm + 75-300mm Lens + ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "CMOS",
+          "Wi-Fi"
+        ],
+        "link": "https://www.bestbuy.com/site/nikon-z-9-8k-video-mirrorless-camera-body-only-black/6486699.p?skuId=6486699&utm_source=feed",
+        "position": 85,
+        "price": 5499.99,
+        "product_id": "6486699",
+        "rating": 4.8,
+        "reviews": 440,
+        "source": "Best Buy",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQ8X_3MeX7wvOY0wHfVml3YllKfK39_L1dT0qvu-6rxkDPikPje1PiWOgs4aHYHyOj3h99wmRu7LgtUL41s5oFfM5I8yRBoPPD8sodISyQ&usqp=CAE",
+        "title": "Nikon Z9 Mirrorless Camera Body"
       },
       {
         "extensions": [
@@ -1265,76 +1370,14 @@ dummy_search_products = {
           "Crop Sensor"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-4000D-Rebel-T100-Camera-Canon-18-55mm-70-300mm-64GB-Memory-Cards-ZeeTech-Accessory-Bundle/997435950?wmlspartner=wlpa&selectedSellerId=6558",
-        "position": 85,
-        "price": 574.99,
-        "rating": 4.5,
-        "reviews": 2030,
-        "source": "Walmart - JumboBuys",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcRMTkamjrAOHAWX9oB_J6YE5q3zz8TCBMDgLC7jKPQGMrZBVGuTETZpv0AnMMEq_e856NxWehK9vZ_CxuZiMyxjVrASyM_GaimxPtdtsCPw&usqp=CAE",
-        "title": "Canon Eos 4000D / Rebel T100 Camera + Canon 18-55mm + 70-300mm +64gb Memory Cards ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "Crop Sensor",
-          "Wi-Fi"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL2-DSLR-Camera-18-55mm-75-300mm-Accessory-Bundle/477592564?wmlspartner=wlpa&selectedSellerId=101020459",
         "position": 86,
-        "price": 849.0,
-        "rating": 4.8,
-        "reviews": 643,
-        "source": "Walmart - Babushkas Market",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQ0dfDc81vMFaiSTmgkz6hG1cd4Bx0BLzvVckUyNonKTZS_OmpWrxZqEtZEUKB3h9vnWnT4Wj4phW3MYwwrnTg6mWrMSH_C&usqp=CAE",
-        "title": "Canon Eos Rebel SL2 DSLR Camera + 18-55mm + 75-300mm Accessory Bundle"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Refurbished-Canon-T6-EOS-Rebel-DSLR-Camera-Kit-with-EF-S-18-55mm-f-3-5-5-6-DC-III-Lens-Black/965596871?wmlspartner=wlpa&selectedSellerId=4012",
-        "position": 87,
-        "price": 364.99,
-        "rating": 4.8,
-        "reviews": 8876,
-        "source": "Walmart - Like New Products LLC",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTpjMgwTsX6sjesRczUpKBF9UTzdgNcV37EYXKwyESM9cUsF3eVM40IhLGM6R_6FxJ4evRqL50dXwcsRKpyS39GTK6YdBQnpTiUznQqaGzhHApch0oFW1VETg&usqp=CAE",
-        "title": "Canon EOS Rebel T6 18.0 MP Digital SLR Camera - Black - EF-S 18-55mm DC III Lens"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black",
-          "SALE"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-1300D-18MP-DSLR-Camera-18-55mm-Lens/106897886?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 88,
-        "price": 424.0,
-        "rating": 4.8,
-        "reviews": 8876,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSHHubhHDvcoaiAF77_1NJVseDrwLtAQrTBhb92_MDbzZoUMdtgvl5sAeH02CV6rCLfef_dcPZJ77o4N-DSu481vkV2LfPdI5KP6N94YaS6JaD8nfN8cR2w6A&usqp=CAE",
-        "title": "Canon EOS Rebel T6 18.0 MP Digital SLR Camera - Black - 18-55mm Lens"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Red",
-          "$56.52 below typical",
-          "LOW PRICE"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3300-DSLR-Camera-w-18-55mm-VR-II-Zoom-Lens-Red-Flash-and-64GB-Kit/172622639?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 89,
-        "price": 663.48,
-        "rating": 4.7,
-        "reviews": 5364,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQs9CBZPCKmHUld4uSVCpTVVXaBKXPgiRebaiTVOeRqGfifH02kpJdB9MBWOCF5-yjh38yCRRBqdQZKVa1sOYZfFYk3o_3fVzTXbXtZdTfuccebKaAd3P_C&usqp=CAE",
-        "title": "Nikon D3300 24.2 MP Digital SLR Camera - 18-55mm VR II Zoom Lens - Flash/64GB Card"
+        "price": 574.99,
+        "product_id": "997435950",
+        "rating": 4.6,
+        "reviews": 2094,
+        "source": "Walmart - JumboBuys",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTp8cSCRQz_TyLwJOJcSY-o6r5O2VchJX1SM-dRmVxUcG_ZAKoqT6hcSco44RHzyKoatuoUNR1HVsI-CVCWhLkKRMBfPB1qzJ2l2xoBB7o&usqp=CAE",
+        "title": "Canon Eos 4000D / Rebel T100 Camera + Canon 18-55mm + 70-300mm +64gb Memory Cards ..."
       },
       {
         "extensions": [
@@ -1343,10 +1386,11 @@ dummy_search_products = {
           "Black"
         ],
         "link": "https://www.walmart.com/ip/Canon-EOS-2000D-DSLR-Camera-18-55mm-IS-II-75-300mm-III-Lens-Essential-Accessory-Bundle-Includes-SanDisk-Ultra-32GB-SDHC-Memory-Card-Wide-Angle-Teleph/206363587?wmlspartner=wlpa&selectedSellerId=5568",
-        "position": 90,
+        "position": 87,
         "price": 659.95,
+        "product_id": "206363587",
         "rating": 4.8,
-        "reviews": 643,
+        "reviews": 681,
         "source": "Walmart - SSE Photo & Video",
         "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcSXmrDXD7Mr-YeoeNsHdVtPNdhs5O3QwzfrnhL7TmLvHVq9QRUzteDCLggDj9aBYGsRGIZJHg9iHQx8hoEdjHCB-vLD87VZ&usqp=CAE",
         "title": "Canon Eos 2000D DSLR Camera with 18-55mm Is II & 75-300mm III Lens & Essential ..."
@@ -1357,105 +1401,80 @@ dummy_search_products = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D7100-DSLR-Digital-Camera-18-55mm-VR-II-70-300mm-f-4-5-6G-Lens-128GB-Memory-2-Batteries-Charger-LED-Video-Light-Backpack-Case-Filters-Auxiliary/46108873?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 91,
-        "price": 1399.0,
+        "link": "https://www.walmart.com/ip/Canon-EOS-800D-24-2-Megapixel-Digital-SLR-Camera-with-Lens-0-71-2-17-Black/977443255?wmlspartner=wlpa&selectedSellerId=18065",
+        "position": 88,
+        "price": 799.0,
+        "product_id": "977443255",
         "rating": 4.8,
-        "reviews": 3669,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcR7eb9D0xR0njOfIYUYZ3-c-XetiV0ujg9gsUo4YDhdrEn4lANoPQJAY0jNsxT1xyieCbFUQHyPZSQqDOOn35H5EmoNZ62b8Msht1TErJvkBa1x06TNYiFO&usqp=CAE",
-        "title": "Nikon D7100 DSLR Digital Camera with 18-55mm VR II + 70-300mm f/4-5.6G Lens + ..."
+        "reviews": 3032,
+        "source": "Walmart - BuzzPhoto",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTX99HvxCyHTdDYdlNEbAp-7zE0cHWT7qX1Ql3MqtdsIRTg-KKTm_TVHP4cHzxgHjFPfYl21t4YoAlt71eSr2tnxMnvlph653-1fg-NVI8&usqp=CAE",
+        "title": "Canon Eos 800D DSLR Camera with 18-55mm Lens, Black"
       },
       {
         "extensions": [
           "CMOS",
-          "With Video",
-          "Black",
-          "$23.82 below typical",
-          "LOW PRICE"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-w-AF-P-DX-NIKKOR-18-55mm-f-3-5-5-6G-VR-Pixi-Starter-Bundle/169532332?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 92,
-        "price": 770.18,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSDVwhFCbxAcMqJGsovdtC36kqtLewmP7MNAShF_98qgMiqugR-XwRZTc8i1Aqlolc1hk6hkuEpU2NlEs4qknaMvZV-T36iXS0GrMjBjJlX&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - Pixi ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-DSLR-Camera-Kit-C/502782643?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 93,
-        "price": 996.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcRpwzDL6yfH4xr-bJeweqXrJmJ6Ev1l54x6uG2JCey5cve16d96OQzNV1Akgi0tGHR17-BaBwHUQ1R9HeJ2h2leivSdHpGKvoRJvihoE94&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - 64 GB ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-2000D-Rebel-T7-DSLR-Camera-18-55mm-III-Kit-Intl-Model/900869799?wmlspartner=wlpa&selectedSellerId=101454533",
-        "position": 94,
-        "price": 399.0,
-        "rating": 4.6,
-        "reviews": 2625,
-        "source": "Walmart - Digi-Master",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSF8gwrWsTxtFo-9u-fKQLW59TztuFXjRyOIcYUD1Ff9Bikm7aP-2JwVvxQd3DWErOvont3TOnXt8Tz5PK8vD6LrqL5zB_OXe5tyvwxf54kiCJxggnJOJTX&usqp=CAE",
-        "title": "Canon Eos 2000D (Rebel T7) DSLR Camera + 18-55mm III Kit"
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "Black"
-        ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24MP-Digital-SLR-Camera-18-55mm-VR-Lens-Great-Value-Kit/967420409?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 95,
-        "price": 996.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcSB0xPjdj1bcZeHuQ3FYbr6xbCgSCsi8gKmgHbFVOMTuK_EpRTktgubMO7Zl7KgHwd5fzOgzbCUDjS4vvLJVWudoAxZ1mP83IKJbe05cAYn&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - Great ..."
-      },
-      {
-        "extensions": [
-          "With Video",
-          "Crop Sensor"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-800D-Rebel-T7i-DSLR-Camera-18-55mm-Lens-Creative-Filter-Set-Bag-Sandisk-Ultra-64GB-Card-6AVE-Electronics-Cleaning-And-More-International-Mo/283934273?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 96,
-        "price": 974.95,
-        "rating": 4.8,
-        "reviews": 2964,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQ08Zqr9hARVNDC6YAMAF8LUMoSCpLPSBqe-JPx6U9OHvncEcjhNysPm-smjTp8R8nRWRHmqu6QxNVOxYvJLdhTraW58HLw_u-n4IXVyTrJfu9A4R8hTNo-&usqp=CAE",
-        "title": "Canon Eos 800D / Rebel T7i DSLR Camera with 18-55mm Lens + Creative Filter Set ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
+          "Crop Sensor",
           "Wi-Fi"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-2000D-Digital-SLR-Camera-with-EF-S-18-55mm-f-3-5-5-6-Is-Lens-2pc-SanDisk-Ultra-32GB-Memory-Cards-Bundle/995228645?wmlspartner=wlpa&selectedSellerId=101006116",
-        "position": 97,
-        "price": 690.5,
+        "link": "https://www.walmart.com/ip/Nikon-D7500-DSLR-Camera-Kit-with-18-55mm-VR-Zoom-Lens-32GB-Memory-Case-Tripod-w-Hand-Grip-and-More28pc-Bundle/803178558?wmlspartner=wlpa&selectedSellerId=5323",
+        "position": 89,
+        "price": 1189.0,
+        "product_id": "803178558",
         "rating": 4.8,
-        "reviews": 8876,
-        "source": "Walmart - Jet$ale",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcQUeyVTI92zwKuQYE7HyovTAouwWy9ggzb5rFx7Q46TGFIrDuDIFRduI4OANOmfGvtB0HLoiS7uNm3Y2MyRvvYd3Um1wSZLLg&usqp=CAE",
-        "title": "Canon Eos Rebel T6/2000d Digital SLR Camera with EF-S 18-55mm f/3.5-5.6 Is Lens ..."
+        "reviews": 996,
+        "source": "Walmart - Als Variety",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcReA9EEh4df0X5BiRAGog1c6WUE6gVtfUdeIpLhulj4_TZlG80OY-H8jku7h1bxsspPaTUfDH0pJ5UEdwCcjMN3VBOpqsM_Nw&usqp=CAE",
+        "title": "Nikon D7500 DSLR Camera Kit with 18-55mm VR Zoom Lens,32GB Memory, Case,Tripod w ..."
+      },
+      {
+        "extensions": [
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Restored-Nikon-D3400-24-2MP-DSLR-Camera-with-18-55mm-VR-and-70-300mm-Dual-Lens-Black-Refurbished/413065676?wmlspartner=wlpa&selectedSellerId=932",
+        "position": 90,
+        "price": 799.0,
+        "product_id": "413065676",
+        "rating": 4.7,
+        "reviews": 3995,
+        "source": "Walmart - OneStopShop",
+        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcSZHB7dto4XslRVGJqVhgb4Wag6ffXUKY6w67RfpbWIV9lHU8FeAXekbQNa2rYT0XveKE4J_XC2ntKZCVetLl1QPJVwo277OD043CrOyR4&usqp=CAE",
+        "title": "Nikon D3400 24.2MP DSLR Camera with 18-55mm VR and 70-300mm"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-2000D-DSLR-Camera-with-18-55mm-Lens-EF-S-75-300mm-Lens-Bundle/186200168?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 91,
+        "price": 741.08,
+        "product_id": "186200168",
+        "rating": 4.8,
+        "reviews": 9113,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcS8atJCB8wTkRI_wudCw6q_w_uANVfL5kbmQBfbHFuzbBcbxfzeEcE3hFoUNOL8DmzoqajPikxAzvLNwl9nHjdqUwTlK-P7Z8qo-6dFBbin&usqp=CAE",
+        "title": "Canon EOS Rebel T6 18.0 MP Digital SLR Camera - Black - EF-S 18-55mm IS and EF-S ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi",
+          "$129.00 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-90D-DSLR-Camera-with-18-55mm-Pixi-Essential-Bundles/567352148?wmlspartner=wlpa&selectedSellerId=8054",
+        "position": 92,
+        "price": 1070.0,
+        "product_id": "567352148",
+        "rating": 4.7,
+        "reviews": 337,
+        "source": "Walmart - Deal-Expo",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcTUg4gFYzKpW681LW38XSh1hYPmNl3Og7xVzI6DgoiuBLC8dVAbA7zatNVCw8dU3IKKLfAxJfH245DzDJ_zYLhM8NDoIXibtw&usqp=CAE",
+        "title": "Canon Eos 90D DSLR Camera with 18-55mm + Pixi Essential Bundles"
       },
       {
         "extensions": [
@@ -1464,8 +1483,9 @@ dummy_search_products = {
           "SALE"
         ],
         "link": "https://www.walmart.com/ip/NBD-DSLR-Camera-33MP-Digital-SLR-4K-Camcorder-24X-Telephoto-Lens-Wide-Angle-Lens-IPS-Screen-YouTube-Vlogging-32GB-SD-Card-Included/1747220129?wmlspartner=wlpa&selectedSellerId=101173561",
-        "position": 98,
+        "position": 93,
         "price": 299.0,
+        "product_id": "1747220129",
         "rating": 3.4,
         "reviews": 15,
         "source": "Walmart - ningboshi yinzhou zhoubatian guojimaoyi youxiangongsi",
@@ -1475,32 +1495,117 @@ dummy_search_products = {
       {
         "extensions": [
           "CMOS",
-          "With Video",
-          "Black"
+          "Crop Sensor",
+          "Wi-Fi"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24-2-MP-Digital-SLR-Camera-with-Top-Accessory-Bundle/595669147?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 99,
-        "price": 899.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQmlp2J5IvEu7AuUNtmimtYaQTlQJp7qug34s0NlliqfJ4NbFRZl0RtfEBEwoaULDczVjlyIuwXkPkm_kRx5FlVeby102f-stcyi8i_koBnT2lhVi5Ummi4pQ&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - Top ..."
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-SL2-DSLR-Camera-18-55mm-75-300mm-Accessory-Bundle/477592564?wmlspartner=wlpa&selectedSellerId=101020459",
+        "position": 94,
+        "price": 849.0,
+        "product_id": "477592564",
+        "rating": 4.8,
+        "reviews": 681,
+        "source": "Walmart - Babushkas Market",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQ0dfDc81vMFaiSTmgkz6hG1cd4Bx0BLzvVckUyNonKTZS_OmpWrxZqEtZEUKB3h9vnWnT4Wj4phW3MYwwrnTg6mWrMSH_C&usqp=CAE",
+        "title": "Canon Eos Rebel SL2 DSLR Camera + 18-55mm + 75-300mm Accessory Bundle"
       },
       {
         "extensions": [
           "CMOS",
           "With Video",
-          "White"
+          "Wi-Fi"
         ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-Digital-SLR-Camera-18-55mm-and-75-300mm-Zoom-Lenses-International-Model-No-Warranty/235540697?wmlspartner=wlpa&selectedSellerId=4720",
-        "position": 100,
-        "price": 829.95,
+        "link": "https://www.walmart.com/ip/Nikon-D3300-D3500-DSLR-Camera-with-18-55mm-VR-II-and-70-300mm-VR-Lenses/728222221?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 95,
+        "price": 952.85,
+        "product_id": "728222221",
+        "rating": 4.7,
+        "reviews": 5424,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcTqt_i-OrWLXJ7zPTQTuzrlgtVAJ63lIHhhf4ETKjhwaMNHYTNydWrxAtIkZ_s3dgl6bg6RfUks40y65wVC2kd2Gnlw9skHYPhUL83cJTCIGJ2vvgvROaoh6A&usqp=CAE",
+        "title": "Nikon D3300 DSLR Camera with 18-55mm & AF-P DX NIKKOR 70-300mm Lens"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Silver"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D7100-DSLR-Camera-with-18-105mm-Lens/647580935?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 96,
+        "price": 1607.0,
+        "product_id": "647580935",
         "rating": 4.8,
-        "reviews": 8876,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcR9OSLCorJh6N2ts8-zMMoVM-UzqDIWbFB8EYsvRqpsohpx2MQXH4yG5haN3CPeapV6Jx9MMlPyBH6hcfFk57aiKardctr5Qg&usqp=CAE",
-        "title": "Canon Eos Rebel T6 Digital SLR Camera 18-55mm and 75-300mm Zoom Lenses"
+        "reviews": 3102,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcSEfKauWrMNU_7pePc5B6M1H7eUDcxksscBLXHkoiCUPwtf4KwYGU2UmIeNq-78KpkiTnZNrko8DlKeYWT0g2qGF5GSob8_D3sbx3I1AEppGTZblZloWq0fDQ&usqp=CAE",
+        "title": "Nikon D7100 DSLR Camera with 18-105mm Lens"
+      },
+      {
+        "extensions": [
+          "Detachable Flash",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D3400-24-2-MP-Digital-SLR-Camera-Black-AF-P-DX-18-55mm-VR-and-70-300mm-Lenses-30-piece-Accessory-Bundle/746627998?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 97,
+        "price": 1194.0,
+        "product_id": "746627998",
+        "rating": 4.7,
+        "reviews": 3995,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn0.gstatic.com/shopping?q=tbn:ANd9GcQCfMKTWWUYa3JiypmW2hRaAVDum7lRttITaOE1r1BCCXz-rBCVWYPsnFfW8-GTYtG3N0_0CqDHmwpruvROndu4wjpPKGQr&usqp=CAE",
+        "title": "Nikon D3400 24.2 Mp Digital SLR Camera - Black - AF-P DX 18-55mm VR and 70-300mm ..."
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Red",
+          "$36.47 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Nikon-D3300-DSLR-Camera-w-18-55mm-VR-II-Zoom-Lens-Red-Flash-and-64GB-Kit/172622639?wmlspartner=wlpa&selectedSellerId=6811",
+        "position": 98,
+        "price": 663.48,
+        "product_id": "172622639",
+        "rating": 4.7,
+        "reviews": 5424,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQs9CBZPCKmHUld4uSVCpTVVXaBKXPgiRebaiTVOeRqGfifH02kpJdB9MBWOCF5-yjh38yCRRBqdQZKVa1sOYZfFYk3o_3fVzTXbXtZdTfuccebKaAd3P_C&usqp=CAE",
+        "title": "Nikon D3300 24.2 MP Digital SLR Camera - 18-55mm VR II Zoom Lens - Flash/64GB Card"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi",
+          "$129.00 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-90D-DSLR-Camera-with-18-55mm-Pixi-Advanced-Bundle/487096375?wmlspartner=wlpa&selectedSellerId=8054",
+        "position": 99,
+        "price": 1070.0,
+        "product_id": "487096375",
+        "rating": 4.7,
+        "reviews": 337,
+        "source": "Walmart - Deal-Expo",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRwXpswMkt7R7x5VLAfVdAC_m2iOkTO2TyIn1ou2xOwgFBcA5R1nROskW4zxYle6iwFxW75bzeW4MESZq-0YYvasmkqPeaurg&usqp=CAE",
+        "title": "Canon Eos 90D DSLR Camera with 18-55mm + Pixi Advanced Bundle"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Black"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-DSLR-Camera-w-EF-S-18-55mm-f-3-5-5-6-DC-Lens-International-Model/580098844?wmlspartner=wlpa&selectedSellerId=101454533",
+        "position": 100,
+        "price": 325.0,
+        "product_id": "580098844",
+        "rating": 4.5,
+        "reviews": 649,
+        "source": "Walmart - Digi-Master",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRfBEz9Zx7IbIvPJmIZl8JzL5PPjLaEzDOb-2eY3cTZIg-NOXxCHJeW5R7YXfPOGpCnQG15DgwgpAove9ksVZPL5hWkXKV4rvyYNuBUYEvy3_shXiFKXOFF&usqp=CAE",
+        "title": "Canon Eos Rebel T100 DSLR Camera EF-S 18-55mm f/3.5-5.6 DC III"
       }
     ],
     "pagination": {
@@ -1522,18 +1627,39 @@ dummy_search_products2 = {
     "data": [
       {
         "extensions": [
+          "CMOS",
           "With Video",
-          "Black",
-          "SALE"
+          "Red",
+          "$36.47 below typical",
+          "LOW PRICE"
         ],
-        "link": "https://www.walmart.com/ip/NBD-DSLR-Camera-33MP-Digital-SLR-4K-Camcorder-24X-Telephoto-Lens-Wide-Angle-Lens-IPS-Screen-YouTube-Vlogging-32GB-SD-Card-Included/1747220129?wmlspartner=wlpa&selectedSellerId=101173561",
+        "link": "https://www.walmart.com/ip/Nikon-D3300-DSLR-Camera-w-18-55mm-VR-II-Zoom-Lens-Red-Flash-and-64GB-Kit/172622639?wmlspartner=wlpa&selectedSellerId=6811",
         "position": 98,
-        "price": 299.0,
-        "rating": 3.4,
-        "reviews": 15,
-        "source": "Walmart - ningboshi yinzhou zhoubatian guojimaoyi youxiangongsi",
-        "thumbnail": "https://encrypted-tbn2.gstatic.com/shopping?q=tbn:ANd9GcTp4DdWmf-vLzSqgd8VJ0dKWObb9Jdca5GmmkvaiFwvI0BejicnRtTNv2aAYyB8SRjiyMX6PnbpxcZlt96XvCtbzHyC9hk6cxcgsPzCcGxD7Sp5Ydp_bmw_&usqp=CAE",
-        "title": "Nbd DSLR Camera ,33mp Digital SLR Camera 4K Digital Camera Camcorder with 24x ..."
+        "price": 663.48,
+        "product_id": "172622639",
+        "rating": 4.7,
+        "reviews": 5424,
+        "source": "Walmart - BuyDirect & Save",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQs9CBZPCKmHUld4uSVCpTVVXaBKXPgiRebaiTVOeRqGfifH02kpJdB9MBWOCF5-yjh38yCRRBqdQZKVa1sOYZfFYk3o_3fVzTXbXtZdTfuccebKaAd3P_C&usqp=CAE",
+        "title": "Nikon D3300 24.2 MP Digital SLR Camera - 18-55mm VR II Zoom Lens - Flash/64GB Card"
+      },
+      {
+        "extensions": [
+          "CMOS",
+          "With Video",
+          "Wi-Fi",
+          "$129.00 below typical",
+          "LOW PRICE"
+        ],
+        "link": "https://www.walmart.com/ip/Canon-EOS-90D-DSLR-Camera-with-18-55mm-Pixi-Advanced-Bundle/487096375?wmlspartner=wlpa&selectedSellerId=8054",
+        "position": 99,
+        "price": 1070.0,
+        "product_id": "487096375",
+        "rating": 4.7,
+        "reviews": 337,
+        "source": "Walmart - Deal-Expo",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRwXpswMkt7R7x5VLAfVdAC_m2iOkTO2TyIn1ou2xOwgFBcA5R1nROskW4zxYle6iwFxW75bzeW4MESZq-0YYvasmkqPeaurg&usqp=CAE",
+        "title": "Canon Eos 90D DSLR Camera with 18-55mm + Pixi Advanced Bundle"
       },
       {
         "extensions": [
@@ -1541,29 +1667,15 @@ dummy_search_products2 = {
           "With Video",
           "Black"
         ],
-        "link": "https://www.walmart.com/ip/Nikon-D3400-24-2-MP-Digital-SLR-Camera-with-Top-Accessory-Bundle/595669147?wmlspartner=wlpa&selectedSellerId=6811",
-        "position": 99,
-        "price": 899.0,
-        "rating": 4.7,
-        "reviews": 7323,
-        "source": "Walmart - BuyDirect & Save",
-        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcQmlp2J5IvEu7AuUNtmimtYaQTlQJp7qug34s0NlliqfJ4NbFRZl0RtfEBEwoaULDczVjlyIuwXkPkm_kRx5FlVeby102f-stcyi8i_koBnT2lhVi5Ummi4pQ&usqp=CAE",
-        "title": "Nikon D3400 24.2 MP Digital SLR Camera - Black - AF-P DX 18-55mm VR Lens - Top ..."
-      },
-      {
-        "extensions": [
-          "CMOS",
-          "With Video",
-          "White"
-        ],
-        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T6-Digital-SLR-Camera-18-55mm-and-75-300mm-Zoom-Lenses-International-Model-No-Warranty/235540697?wmlspartner=wlpa&selectedSellerId=4720",
+        "link": "https://www.walmart.com/ip/Canon-EOS-Rebel-T100-DSLR-Camera-w-EF-S-18-55mm-f-3-5-5-6-DC-Lens-International-Model/580098844?wmlspartner=wlpa&selectedSellerId=101454533",
         "position": 100,
-        "price": 829.95,
-        "rating": 4.8,
-        "reviews": 8876,
-        "source": "Walmart - 6AVE Electronics",
-        "thumbnail": "https://encrypted-tbn3.gstatic.com/shopping?q=tbn:ANd9GcR9OSLCorJh6N2ts8-zMMoVM-UzqDIWbFB8EYsvRqpsohpx2MQXH4yG5haN3CPeapV6Jx9MMlPyBH6hcfFk57aiKardctr5Qg&usqp=CAE",
-        "title": "Canon Eos Rebel T6 Digital SLR Camera 18-55mm and 75-300mm Zoom Lenses"
+        "price": 325.0,
+        "product_id": "580098844",
+        "rating": 4.5,
+        "reviews": 649,
+        "source": "Walmart - Digi-Master",
+        "thumbnail": "https://encrypted-tbn1.gstatic.com/shopping?q=tbn:ANd9GcRfBEz9Zx7IbIvPJmIZl8JzL5PPjLaEzDOb-2eY3cTZIg-NOXxCHJeW5R7YXfPOGpCnQG15DgwgpAove9ksVZPL5hWkXKV4rvyYNuBUYEvy3_shXiFKXOFF&usqp=CAE",
+        "title": "Canon Eos Rebel T100 DSLR Camera EF-S 18-55mm f/3.5-5.6 DC III"
       }
     ],
     "pagination": {

--- a/frontend/src/pages/product-search/ProductSearch.jsx
+++ b/frontend/src/pages/product-search/ProductSearch.jsx
@@ -16,11 +16,16 @@ function ProductSearch() {
     const location = useLocation();
 
     const _searchProductsHelper = (q) => {
-        // TODO: Update from links to id (or entire product if possible).
-        const selectedLinks = [...mainSelectedProducts.map(p => p.link), ...currentSelectedProducts.map(p => p.link)];
+        if (q === "") {
+            setSearchQuery(q);
+            setProductData([]);
+            setProductPagination({});
+            return;
+        }
+        const selectedIds = [...mainSelectedProducts.map(p => p.product_id), ...currentSelectedProducts.map(p => p.product_id)];
         const searchEndpoint = `${process.env.REACT_APP_BACKEND_BASE_API}/api/dummy/search-products?q=${q}`;
         fetch(searchEndpoint).then(res => res.json()).then(data => {
-            const prodData = data.shopping_results.data.filter(p => !selectedLinks.includes(p.link));
+            const prodData = data.shopping_results.data.filter(p => !selectedIds.includes(p.product_id));
             setProductData(prodData);
             setProductPagination(data.shopping_results.pagination);
         });
@@ -48,7 +53,6 @@ function ProductSearch() {
         _searchProductsHelper(searchQuery);
     }
 
-    // TODO: Update unique product value from link to product_id.
     const onProductSelection = (product) => {
         if (mainSelectedProducts.includes(product)) {
             setMainSelectedProducts(mainSelectedProducts.filter(p => p !== product));


### PR DESCRIPTION
## Link to Ticket
https://trello.com/c/ZGWDgbQH

## Brief Description of Changes
- Previous PR added `product_id` field to endpoint, this PR utilizes it
- Note that the massive changes in the `dummy_search_products` can probably just be ignored/doesn't require review. The reason it says there's a lot of changes is because I just re-ran the actual `search-products` endpoint and copied the results (so `product_id` exists on each product)

## Checklist
- [X] I do not commit the .env file.
- [X] I added my changes to the appropriate frontend or backend folders.
- [X] All aspects of the ticket have been entirely addressed and completed.
- [ ] Thorough automated tests have been added.
- [X] Functionality has been validated through manual tests.
- [ ] I have received approval from a peer before merging.
