### PR TITLE
Add token limitation

### DIFF
--- a/backend/src/summarize/summarize.py
+++ b/backend/src/summarize/summarize.py
@@ -6,10 +6,19 @@ def summarize(reviews: List[str]) -> str:
     if len(reviews) == 0:
         return "Product has no reviews."
 
-    # TODO: Need to limit to under 4097 tokens.
+    # Limit to under 4000 tokens.
+    shorted_reviews = []
+    max_tokens = 4000 # Actual max is 4098, but would prefer some buffer.
+    total_tokens = 0
+    for review in reviews:
+        tokens = len(review.split())
+        if total_tokens + tokens <= max_tokens:
+            shorted_reviews.append(review)
+            total_tokens += tokens
+
     client = OpenAI(api_key=environ.get("OPENAI_API_KEY"))
     # TODO: Maybe can add more to prompt (e.g. "using at most 100 words").
-    bullet_reviews = "\n- ".join(reviews)
+    bullet_reviews = "\n- ".join(shorted_reviews)
     prompt = f"Summarize and aggregate the following list of product reviews into 1 paragraph:\n- {bullet_reviews}"
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",

--- a/backend/test/summarize/test_summarize.py
+++ b/backend/test/summarize/test_summarize.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from src.summarize.summarize import summarize
 
+# TODO: Impove test by confirming .create() call_args takes in bullet list of reviews.
 class TestSummarize(unittest.TestCase):
     def test_summarize_no_reviews(self):
         reviews = []
@@ -12,7 +13,6 @@ class TestSummarize(unittest.TestCase):
 
     @patch("src.summarize.summarize.OpenAI")
     def test_summarize_with_reviews(self, openai_mock):
-        # TODO: Impove test by confirming .create() call_args takes in bullet list of reviews.
         reviews = [
             "This product stinks",
             "One of the best purchases I ever made",
@@ -20,6 +20,14 @@ class TestSummarize(unittest.TestCase):
             "I'mm stll lrning to tpe, but my fvorite prodct ever",
             "4.5 stars? How is that possible. Should have a negative rating",
         ]
+        summarize(reviews)
+        kwargs = openai_mock.call_args.kwargs
+        expected = {"api_key": None}
+        self.assertEqual(kwargs, expected)
+
+    @patch("src.summarize.summarize.OpenAI")
+    def test_summarize_under_4000_tokens(self, openai_mock):
+        reviews = ["two words"] * 5000
         summarize(reviews)
         kwargs = openai_mock.call_args.kwargs
         expected = {"api_key": None}


### PR DESCRIPTION
## Brief Description of Changes
- Passing at most 4000 words to summarization API since limit is 4098 tokens.

## Checklist
- [X] I do not commit the .env file.
- [X] I added my changes to the appropriate frontend or backend folders.
- [X] All aspects of the ticket have been entirely addressed and completed.
- [X] Thorough automated tests have been added.
- [X] Functionality has been validated through manual tests.
- [ ] I have received approval from a peer before merging.
