### PR TITLE
updated recommendation calculation weights

### DIFF
--- a/backend/src/recommendations/recommendations.py
+++ b/backend/src/recommendations/recommendations.py
@@ -137,7 +137,6 @@ class Recommendation:
                 brand_diff = 0
 
             # Megapixels: ["<15", "15-30", "30-45", ">45", ""]
-            # TODO: More megapixels are better?
             if "-" in preferences.get("megapixels"):
                 lower_bound = int(preferences.get("megapixels")[:preferences.get("megapixels").index("-")])
                 upper_bound = int(preferences.get("megapixels")[preferences.get("megapixels").index("-") + 1:])
@@ -203,9 +202,8 @@ class Recommendation:
             # Sum all weights.
             pref_score = sum(weights.values())
 
-            # TODO: Verify the weights.
-            rank_weight = 0.25
-            pref_weight = 0.75
+            rank_weight = 0.4
+            pref_weight = 0.6
             worst_score = pref_weight * sum(range(1, NUM_FEATURES + 1)) + rank_weight * (max_master_list_rank + max_rank * 2)
             # Prepare all products for table.
             recommendations.append({

--- a/backend/test/recommendations/test_recommendations.py
+++ b/backend/test/recommendations/test_recommendations.py
@@ -47,21 +47,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 4.16,
+                "score": 4.09,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 1.67,
+                "score": 1.60,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 0.93,
+                "score": 0.78,
             },
         ]
         self.assertEqual(result, expected)
@@ -74,21 +74,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 4.16,
+                "score": 4.09,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 3.94,
+                "score": 3.49,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 3.21,
+                "score": 2.67,
             },
         ]
         self.assertEqual(result, expected)
@@ -102,21 +102,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 4.54,
+                "score": 4.41,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 3.94,
+                "score": 3.49,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 3.78,
+                "score": 3.15,
             },
         ]
         self.assertEqual(result, expected)
@@ -136,14 +136,14 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 1.61,
+                "score": 1.55,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 0.31,
+                "score": 0.26,
             },
         ]
         self.assertEqual(result, expected)
@@ -156,21 +156,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 3.96,
+                "score": 3.93,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 2.07,
+                "score": 1.94,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 0.54,
+                "score": 0.45,
             },
         ]
         self.assertEqual(result, expected)
@@ -183,21 +183,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 4.63,
+                "score": 4.48,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 4.07,
+                "score": 3.59,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 3.87,
+                "score": 3.22,
             },
         ]
         self.assertEqual(result, expected)
@@ -211,21 +211,21 @@ class TestRecommendation(unittest.TestCase):
                 "title": "New Product Title",
                 "price": 300.0,
                 "source": "Best Buy",
-                "score": 4.16,
+                "score": 4.09,
             },
             {
                 "product_id": "444",
                 "title": "New Product Title",
                 "price": 600.0,
                 "source": "Walmart",
-                "score": 1.67,
+                "score": 1.60,
             },
             {
                 "product_id": "999",
                 "title": "New Product Title",
                 "price": None,
                 "source": "Best Buy",
-                "score": 0.93,
+                "score": 0.78,
             },
         ]
         self.assertEqual(result, expected)


### PR DESCRIPTION
## Link to Ticket
https://trello.com/c/bm1qOH3d/191-recommendation-model-lit-review-on-25-vs-75-importance

## Brief Description of Changes

- Updated popularity weight from 0.25 to 0.4 and preferences weight from 0.75 to 0.6
- Updated tests

## Checklist
- [x] I do not commit the .env file.
- [x] I added my changes to the appropriate frontend or backend folders.
- [x] All aspects of the ticket have been entirely addressed and completed.
- [x] Thorough automated tests have been added.
- [x] Functionality has been validated through manual tests.
- [ ] I have received approval from a peer before merging.
