### PR TITLE
Max height photos

### DIFF
--- a/frontend/src/components/comparison/comparison-data/ComparisonData.css
+++ b/frontend/src/components/comparison/comparison-data/ComparisonData.css
@@ -38,8 +38,7 @@
 .comparison-product-image {
 	display: block;
 	max-width: 100%;
-	height: 100%;
-	max-height: 100%;
+	height: 300px;
     margin: 0 auto;
 	padding: 4%;
 }

--- a/frontend/src/components/comparison/comparison-data/ComparisonData.css
+++ b/frontend/src/components/comparison/comparison-data/ComparisonData.css
@@ -37,7 +37,8 @@
 /* BASIC INFO */
 .comparison-product-image {
 	display: block;
-	width: 100%;
+	max-width: 100%;
+	height: 100%;
 	max-height: 100%;
     margin: 0 auto;
 	padding: 4%;

--- a/frontend/src/components/product-option/ProductOption.css
+++ b/frontend/src/components/product-option/ProductOption.css
@@ -1,4 +1,8 @@
 .product-container {
+	display: grid;
+	grid-template-rows: 1fr;
+	grid-template-areas: "overlayarea";
+	position: relative;
 	border-radius: 8px;
 }
 
@@ -13,12 +17,15 @@
 }
 
 .product-content {
+	grid-area: overlayarea;
+	display: contents;
 	position: relative;
     width: 100%;
 	text-align: left;
 }
 
 .selection-number {
+	grid-area: overlayarea;
 	background: var(--PRIMARY-BLUE);
 	color: var(--OFF-WHITE);
 	position: absolute;
@@ -29,24 +36,34 @@
 	border-radius: 50%;
 	text-align: center;
 	line-height: 32px;
+	z-index: 20;
 }
 
 .basic-details-container {
+	grid-row: 1;
+	position: relative;
+	display: contents;
 	padding: 5%;
 }
 
 .product-image {
+	display: block;
 	-webkit-user-drag: none;
 	inset: 0;
-	max-width: 100%;
-	height: 100%;
 	max-height: 100%;
+	max-width: 95%;
 	padding: 2%;
+	margin: auto auto;
 }
 
 .product-title {
-	padding-bottom: 10px;
+	padding: 2% 5% 2% 5%;
 	min-height: 80px;
+}
+
+.product-rating {
+	margin: auto auto;
+	padding: 2% 5% 2% 5%;
 }
 
 .selected-product-line { 
@@ -58,7 +75,6 @@
 }
 
 .price-and-link-container {
-	height: 5%;
 	padding: 2% 5% 2% 5%;
 }
 

--- a/frontend/src/components/product-option/ProductOption.jsx
+++ b/frontend/src/components/product-option/ProductOption.jsx
@@ -14,7 +14,9 @@ function ProductOption(props) {
                 <div className="basic-details-container">
                     <img className="product-image" src={props.data.thumbnail} alt=""/>
                     <p className="body-2-medium product-title">{props.data.title}</p>
-                    <Rating rating={props.data.rating} reviews={props.data.reviews} isCenter={false}/>
+                    <div className="product-rating">
+                        <Rating rating={props.data.rating} reviews={props.data.reviews} isCenter={false}/>
+                    </div>
                 </div>
                 <hr className={selectedLineStyle} />
                 <div className="price-and-link-container">


### PR DESCRIPTION
## Link to Ticket
https://trello.com/c/Ga576G0b/224-frontend-max-height-for-product-images
https://trello.com/c/9C2M50BD/248-frontend-selected-product-circles

## Brief Description of Changes

- Set max-height for comparison table images
- Aligned selected product number for all products
- Image, text, rating are aligned for products on search page (for the most part I think?)

## Checklist
- [x] I do not commit the .env file.
- [x] I added my changes to the appropriate frontend or backend folders.
- [x] All aspects of the ticket have been entirely addressed and completed.
- [ ] Thorough automated tests have been added.
- [x] Functionality has been validated through manual tests.
- [ ] I have received approval from a peer before merging.
